### PR TITLE
Renamed podspec for cocoapods

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ script. Running this script on Xcode 6.1.1 (`6A2008a`) on the revision
 `cae09d458a4509614c6cdb32e93ab2f6263c18ce` of libsodium generates a file
 identical to the one present in this repository.
 
+or using CocoaPods
+------------------
+
+```
+pod 'Sodium', '~> 0.1'
+```
+
 Public-key authenticated encryption
 ===================================
 

--- a/Sodium.podspec
+++ b/Sodium.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+s.name = 'Sodium'
+s.version = '0.1'
+s.license = 'Frank Denis'
+s.summary = 'Swift-Sodium provides a safe and easy to use interface to perform common cryptographic operations on iOS and OSX.'
+s.homepage = 'https://github.com/jedisct1/swift-sodium'
+s.social_media_url = 'http://twitter.com/jedisct1'
+s.authors = { 'Frank Denis' => '' }
+s.source = { :git => 'https://github.com/jedisct1/swift-sodium.git' }
+# s.source = { :git => 'https://github.com/jedisct1/swift-sodium.git', :tag => s.version }
+
+s.ios.deployment_target = '8.0'
+s.osx.deployment_target = '10.9'
+
+s.vendored_library    = 'Sodium/libsodium.a'
+
+s.source_files = 'Sodium/*.{swift,h}'
+
+s.requires_arc = true
+end


### PR DESCRIPTION
Sorry for the confusion @jedisct1.

I have renamed the podspec from `swift-sodium` to `Sodium` as it will be easier for the user to use it as described in the documentation. 
Now dev can add `import Sodium`, otherwise he has to use `import swift_sodium`, which isn't so nice.

Also I wasn't sure about the license, so you might want to set the correct license like: `s.license     = { :type => "MIT", :file => 'LICENSE' }`

Also, you will have to push the podspec to the CocoaPods servers, as you are the owner.
For now users can use it like:
```
pod 'swift-sodium', git: 'https://github.com/jedisct1/swift-sodium.git', :branch => 'master'
```