### PR TITLE
added func overloads for anonymous seal and open

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ Running these scripts on Xcode 7.0 (`7A220`) on the revision
 `437b20161ca0271756e5c2b6078a94dd63b51493` of libsodium generate files
 identical to the ones present in this repository.
 
-Public-key authenticated encryption
-===================================
+Public-key Cryptography
+=======================
+
+Authenticated Encryption
+------------------------
 
 ```swift
 let sodium = Sodium()!
@@ -61,6 +64,30 @@ ciphertext. `open()` extracts the nonce and decrypts the ciphertext.
 The `Box` class also provides alternative functions and parameters to
 deterministically generate key pairs, to retrieve the nonce and/or the
 authenticator, and to detach them from the original message.
+
+Anonymous Encryption (Sealed Boxes)
+-----------------------------------
+
+```swift
+let sodium = Sodium()!
+let bobKeyPair = sodium.box.keyPair()!
+let message: NSData = "My Test Message".toData()!
+
+let encryptedMessageToBob: NSData =
+  sodium.box.seal(message, recipientPublicKey: bobKeyPair.publicKey)!
+
+let messageDecryptedByBob =
+  sodium.box.open(encryptedMessageToBob,
+                  recipientPublicKey: bobKeyPair.publicKey,
+                  recipientSecretKey: bobKeyPair.secretKey)
+```
+
+`seal()` generates an ephemeral keypair, uses the ephemeral secret 
+key in the encryption process, combines the ephemeral public key with
+the ciphertext, then destroys the keypair. The sender can not decrypt
+the resulting ciphertext. `open()` extracts the public key and decrypts
+using the recipient's secret key. Message integrity is verified, but 
+the sender's identity cannot be correlated to the ciphertext.
 
 Public-key signatures
 =====================

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -213,11 +213,10 @@ public class Box {
         if recipientPublicKey.length != PublicKeyBytes {
             return nil
         }
-        let anonymousCipherText = NSMutableData(length: SealBytes + message.length)
-        if anonymousCipherText == nil {
+        guard let anonymousCipherText = NSMutableData(length: SealBytes + message.length) else {
             return nil
         }
-        if crypto_box_seal(anonymousCipherText!.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), recipientPublicKey.bytesPtr) != 0 {
+        if crypto_box_seal(anonymousCipherText.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), recipientPublicKey.bytesPtr) != 0 {
             return nil
         }
         return anonymousCipherText

--- a/SodiumTests/SodiumTests.swift
+++ b/SodiumTests/SodiumTests.swift
@@ -49,6 +49,11 @@ class SodiumTests: XCTestCase {
         let decrypted3 = sodium.box.open(encryptedMessageFromAliceToBob3, senderPublicKey: aliceKeyPair.publicKey, recipientSecretKey: bobKeyPair.secretKey, nonce: nonce2, mac: mac)
         XCTAssert(decrypted3 == message)
         
+        let encryptedMessageToBob: NSData = sodium.box.seal(message, recipientPublicKey: bobKeyPair.publicKey)!
+        let decrypted4 = sodium.box.open(encryptedMessageToBob, recipientPublicKey: bobKeyPair.publicKey,
+            recipientSecretKey: bobKeyPair.secretKey)
+        XCTAssert(decrypted4 == message)
+
         // beforenm tests
         // The two beforenm keys calculated by Alice and Bob separately should be identical
         let aliceBeforenm = sodium.box.beforenm(bobKeyPair.publicKey, senderSecretKey: aliceKeyPair.secretKey)!
@@ -64,7 +69,7 @@ class SodiumTests: XCTestCase {
         let decryptedBeforenm2 = sodium.box.open(encryptedMessageBeforenm2, beforenm: aliceBeforenm, nonce: nonceBeforenm)
         XCTAssert(decryptedBeforenm2 == message)
     }
-    
+
     func testSecretBox() {
         let message = "My Test Message".toData()!
         let secretKey = sodium.secretBox.key()!


### PR DESCRIPTION
This PR adds seal() and open() funcs for crypto_box_seal and crypto_box_open, allowing one to anonymously send messages to a recipient given its public key. (docs here: http://doc.libsodium.org/public-key_cryptography/sealed_boxes.html )

I won't quibble too much but it did throw me for a loop that you used the seal verb without actually exposing libsodium's seal method. 😜