### PR TITLE
Adopts guard syntax for early exits

### DIFF
--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -29,53 +29,46 @@ public class Box {
     }
     
     public func keyPair() -> KeyPair? {
-        let pk = NSMutableData(length: PublicKeyBytes)
-        if pk == nil {
+        guard let pk = NSMutableData(length: PublicKeyBytes) else {
             return nil
         }
-        let sk = NSMutableData(length: SecretKeyBytes)
-        if sk == nil {
+        guard let sk = NSMutableData(length: SecretKeyBytes) else {
             return nil
         }
-        if crypto_box_keypair(pk!.mutableBytesPtr, sk!.mutableBytesPtr) != 0 {
+        if crypto_box_keypair(pk.mutableBytesPtr, sk.mutableBytesPtr) != 0 {
             return nil
         }
-        return KeyPair(publicKey: PublicKey(data: pk!), secretKey: SecretKey(data: sk!))
+        return KeyPair(publicKey: PublicKey(data: pk), secretKey: SecretKey(data: sk))
     }
     
     public func keyPair(seed seed: NSData) -> KeyPair? {
         if seed.length != SeedBytes {
             return nil
         }
-        let pk = NSMutableData(length: PublicKeyBytes)
-        if pk == nil {
+        guard let pk = NSMutableData(length: PublicKeyBytes) else {
             return nil
         }
-        let sk = NSMutableData(length: SecretKeyBytes)
-        if sk == nil {
+        guard let sk = NSMutableData(length: SecretKeyBytes) else {
             return nil
         }
-        if crypto_box_seed_keypair(pk!.mutableBytesPtr, sk!.mutableBytesPtr, seed.bytesPtr) != 0 {
+        if crypto_box_seed_keypair(pk.mutableBytesPtr, sk.mutableBytesPtr, seed.bytesPtr) != 0 {
             return nil
         }
-        return KeyPair(publicKey: PublicKey(data: pk!), secretKey: SecretKey(data: sk!))
+        return KeyPair(publicKey: PublicKey(data: pk), secretKey: SecretKey(data: sk))
     }
     
     public func nonce() -> Nonce? {
-        let nonce = NSMutableData(length: NonceBytes)
-        if nonce == nil {
+        guard let nonce = NSMutableData(length: NonceBytes) else {
             return nil
         }
-        randombytes_buf(nonce!.mutableBytesPtr, nonce!.length)
-        return nonce! as Nonce
+        randombytes_buf(nonce.mutableBytesPtr, nonce.length)
+        return nonce as Nonce
     }
     
     public func seal(message: NSData, recipientPublicKey: PublicKey, senderSecretKey: SecretKey) -> NSData? {
-        let sealed: (NSData, Nonce)? = seal(message, recipientPublicKey: recipientPublicKey, senderSecretKey: senderSecretKey)
-        if sealed == nil {
+        guard let (authenticatedCipherText, nonce): (NSData, Nonce) = seal(message, recipientPublicKey: recipientPublicKey, senderSecretKey: senderSecretKey) else {
             return nil
         }
-        let (authenticatedCipherText, nonce) = sealed!
         let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce)
         nonceAndAuthenticatedCipherText.appendData(authenticatedCipherText)
         return nonceAndAuthenticatedCipherText
@@ -85,40 +78,35 @@ public class Box {
         if recipientPublicKey.length != PublicKeyBytes || senderSecretKey.length != SecretKeyBytes {
             return nil
         }
-        let authenticatedCipherText = NSMutableData(length: message.length + MacBytes)
-        if authenticatedCipherText == nil {
+        guard let authenticatedCipherText = NSMutableData(length: message.length + MacBytes) else {
             return nil
         }
-        let nonce = self.nonce()
-        if nonce == nil {
+        guard let nonce = self.nonce() else {
             return nil
         }
-        if crypto_box_easy(authenticatedCipherText!.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), nonce!.bytesPtr, recipientPublicKey.bytesPtr, senderSecretKey.bytesPtr) != 0 {
+        if crypto_box_easy(authenticatedCipherText.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), nonce.bytesPtr, recipientPublicKey.bytesPtr, senderSecretKey.bytesPtr) != 0 {
             return nil
         }
-        return (authenticatedCipherText: authenticatedCipherText!, nonce: nonce!)
+        return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
     }
 
     public func seal(message: NSData, recipientPublicKey: PublicKey, senderSecretKey: SecretKey) -> (authenticatedCipherText: NSData, nonce: Nonce, mac: MAC)? {
         if recipientPublicKey.length != PublicKeyBytes || senderSecretKey.length != SecretKeyBytes {
             return nil
         }
-        let authenticatedCipherText = NSMutableData(length: message.length)
-        if authenticatedCipherText == nil {
+        guard let authenticatedCipherText = NSMutableData(length: message.length) else {
             return nil
         }
-        let mac = NSMutableData(length: MacBytes)
-        if mac == nil {
+        guard let mac = NSMutableData(length: MacBytes) else {
             return nil
         }
-        let nonce = self.nonce()
-        if nonce == nil {
+        guard let nonce = self.nonce() else {
             return nil
         }
-        if crypto_box_detached(authenticatedCipherText!.mutableBytesPtr, mac!.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), nonce!.bytesPtr, recipientPublicKey.bytesPtr, senderSecretKey.bytesPtr) != 0 {
+        if crypto_box_detached(authenticatedCipherText.mutableBytesPtr, mac.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), nonce.bytesPtr, recipientPublicKey.bytesPtr, senderSecretKey.bytesPtr) != 0 {
             return nil
         }
-        return (authenticatedCipherText: authenticatedCipherText!, nonce: nonce! as Nonce, mac: mac! as MAC)
+        return (authenticatedCipherText: authenticatedCipherText, nonce: nonce as Nonce, mac: mac as MAC)
     }
     
     public func open(nonceAndAuthenticatedCipherText: NSData, senderPublicKey: PublicKey, recipientSecretKey: SecretKey) -> NSData? {
@@ -137,11 +125,10 @@ public class Box {
         if senderPublicKey.length != PublicKeyBytes || recipientSecretKey.length != SecretKeyBytes {
             return nil
         }
-        let message = NSMutableData(length: authenticatedCipherText.length - MacBytes)
-        if message == nil {
+        guard let message = NSMutableData(length: authenticatedCipherText.length - MacBytes) else {
             return nil
         }
-        if crypto_box_open_easy(message!.mutableBytesPtr, authenticatedCipherText.bytesPtr, CUnsignedLongLong(authenticatedCipherText.length), nonce.bytesPtr, senderPublicKey.bytesPtr, recipientSecretKey.bytesPtr) != 0 {
+        if crypto_box_open_easy(message.mutableBytesPtr, authenticatedCipherText.bytesPtr, CUnsignedLongLong(authenticatedCipherText.length), nonce.bytesPtr, senderPublicKey.bytesPtr, recipientSecretKey.bytesPtr) != 0 {
             return nil
         }
         return message
@@ -154,11 +141,10 @@ public class Box {
         if senderPublicKey.length != PublicKeyBytes || recipientSecretKey.length != SecretKeyBytes {
             return nil
         }
-        let message = NSMutableData(length: authenticatedCipherText.length)
-        if message == nil {
+        guard let message = NSMutableData(length: authenticatedCipherText.length) else {
             return nil
         }
-        if crypto_box_open_detached(message!.mutableBytesPtr, authenticatedCipherText.bytesPtr, mac.bytesPtr, CUnsignedLongLong(authenticatedCipherText.length), nonce.bytesPtr, senderPublicKey.bytesPtr, recipientSecretKey.bytesPtr) != 0 {
+        if crypto_box_open_detached(message.mutableBytesPtr, authenticatedCipherText.bytesPtr, mac.bytesPtr, CUnsignedLongLong(authenticatedCipherText.length), nonce.bytesPtr, senderPublicKey.bytesPtr, recipientSecretKey.bytesPtr) != 0 {
             return nil
         }
         return message
@@ -176,18 +162,16 @@ public class Box {
         if beforenm.length != BeforenmBytes {
             return nil
         }
-        let authenticatedCipherText = NSMutableData(length: message.length + MacBytes)
-        if authenticatedCipherText == nil {
+        guard let authenticatedCipherText = NSMutableData(length: message.length + MacBytes) else {
             return nil
         }
-        let nonce = self.nonce()
-        if nonce == nil {
+        guard let nonce = self.nonce() else {
             return nil
         }
-        if crypto_box_easy_afternm(authenticatedCipherText!.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), nonce!.bytesPtr, beforenm.bytesPtr) != 0 {
+        if crypto_box_easy_afternm(authenticatedCipherText.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), nonce.bytesPtr, beforenm.bytesPtr) != 0 {
             return nil
         }
-        return (authenticatedCipherText: authenticatedCipherText!, nonce: nonce!)
+        return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
     }
     
     public func open(nonceAndAuthenticatedCipherText: NSData, beforenm: Beforenm) -> NSData? {
@@ -206,22 +190,19 @@ public class Box {
         if beforenm.length != BeforenmBytes {
             return nil
         }
-        let message = NSMutableData(length: authenticatedCipherText.length - MacBytes)
-        if message == nil {
+        guard let message = NSMutableData(length: authenticatedCipherText.length - MacBytes) else {
             return nil
         }
-        if crypto_box_open_easy_afternm(message!.mutableBytesPtr, authenticatedCipherText.bytesPtr, CUnsignedLongLong(authenticatedCipherText.length), nonce.bytesPtr, beforenm.bytesPtr) != 0 {
+        if crypto_box_open_easy_afternm(message.mutableBytesPtr, authenticatedCipherText.bytesPtr, CUnsignedLongLong(authenticatedCipherText.length), nonce.bytesPtr, beforenm.bytesPtr) != 0 {
             return nil
         }
         return message
     }
 
     public func seal(message: NSData, beforenm: Beforenm) -> NSData? {
-        let sealed: (NSData, Nonce)? = seal(message, beforenm: beforenm)
-        if sealed == nil {
+        guard let (authenticatedCipherText, nonce): (NSData, Nonce) = seal(message, beforenm: beforenm) else {
             return nil
         }
-        let (authenticatedCipherText, nonce) = sealed!
         let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce)
         nonceAndAuthenticatedCipherText.appendData(authenticatedCipherText)
         return nonceAndAuthenticatedCipherText

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -22,15 +22,14 @@ public class GenericHash {
     }
     
     public func hash(message: NSData, key: NSData?, outputLength: Int) -> NSData? {
-        let output = NSMutableData(length: outputLength)
-        if output == nil {
+        guard let output = NSMutableData(length: outputLength) else {
             return nil
         }
         var ret: CInt;
         if let key = key {
-            ret = crypto_generichash(output!.mutableBytesPtr, output!.length, message.bytesPtr, CUnsignedLongLong(message.length), key.bytesPtr, key.length)
+            ret = crypto_generichash(output.mutableBytesPtr, output.length, message.bytesPtr, CUnsignedLongLong(message.length), key.bytesPtr, key.length)
         } else {
-            ret = crypto_generichash(output!.mutableBytesPtr, output!.length, message.bytesPtr, CUnsignedLongLong(message.length), nil, 0)
+            ret = crypto_generichash(output.mutableBytesPtr, output.length, message.bytesPtr, CUnsignedLongLong(message.length), nil, 0)
         }
         if ret != 0 {
             return nil
@@ -55,19 +54,19 @@ public class GenericHash {
     }
 
     public class Stream {
-        public var outputLength: Int = 0;
-        private var state: UnsafeMutablePointer<crypto_generichash_state>?;
+        public var outputLength: Int = 0
+        private var state: UnsafeMutablePointer<crypto_generichash_state>?
 
         init?(key: NSData?, outputLength: Int) {
-            state = UnsafeMutablePointer<crypto_generichash_state>.alloc(1);
-            if state == nil {
+            state = UnsafeMutablePointer<crypto_generichash_state>.alloc(1)
+            guard let state = state else {
                 return nil
             }
             var ret: CInt
             if let key = key {
-                ret = crypto_generichash_init(state!, key.bytesPtr, key.length, outputLength)
+                ret = crypto_generichash_init(state, key.bytesPtr, key.length, outputLength)
             } else {
-                ret = crypto_generichash_init(state!, nil, 0, outputLength)
+                ret = crypto_generichash_init(state, nil, 0, outputLength)
             }
             if ret != 0 {
                 return nil
@@ -84,11 +83,10 @@ public class GenericHash {
         }
     
         public func final() -> NSData? {
-            let output = NSMutableData(length: outputLength)
-            if output == nil {
+            guard let output = NSMutableData(length: outputLength) else {
                 return nil
             }
-            if crypto_generichash_final(state!, output!.mutableBytesPtr, output!.length) != 0 {
+            if crypto_generichash_final(state!, output.mutableBytesPtr, output.length) != 0 {
                 return nil
             }
             return output

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -21,33 +21,30 @@ public class PWHash {
         public let MemLimitSensitive = Int(crypto_pwhash_scryptsalsa208sha256_memlimit_sensitive())
 
         public func str(passwd: NSData, opsLimit: Int, memLimit: Int) -> String? {
-            let output = NSMutableData(length: StrBytes)
-            if output == nil {
+            guard let output = NSMutableData(length: StrBytes) else {
                 return nil
             }
-            if crypto_pwhash_scryptsalsa208sha256_str(UnsafeMutablePointer<CChar>(output!.mutableBytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length), CUnsignedLongLong(opsLimit), memLimit) != 0 {
+            if crypto_pwhash_scryptsalsa208sha256_str(UnsafeMutablePointer<CChar>(output.mutableBytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length), CUnsignedLongLong(opsLimit), memLimit) != 0 {
                 return nil
             }
-            return NSString(data: output!, encoding: NSUTF8StringEncoding) as String?
+            return NSString(data: output, encoding: NSUTF8StringEncoding) as String?
         }
 
         public func strVerify(hash: String, passwd: NSData) -> Bool {
-            let hashData = (hash + "\0").dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
-            if hashData == nil {
+            guard let hashData = (hash + "\0").dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false) else {
                 return false
             }
-            return crypto_pwhash_scryptsalsa208sha256_str_verify(UnsafePointer<CChar>(hashData!.bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0
+            return crypto_pwhash_scryptsalsa208sha256_str_verify(UnsafePointer<CChar>(hashData.bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0
         }
 
         public func hash(outputLength: Int, passwd: NSData, salt: NSData, opsLimit: Int, memLimit: Int) -> NSData? {
             if salt.length != SaltBytes {
                 return nil
             }
-            let output = NSMutableData(length: outputLength)
-            if output == nil {
+            guard let output = NSMutableData(length: outputLength) else {
                 return nil
             }
-            if crypto_pwhash_scryptsalsa208sha256(output!.mutableBytesPtr, CUnsignedLongLong(outputLength), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length), salt.bytesPtr, CUnsignedLongLong(opsLimit), memLimit) != 0 {
+            if crypto_pwhash_scryptsalsa208sha256(output.mutableBytesPtr, CUnsignedLongLong(outputLength), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length), salt.bytesPtr, CUnsignedLongLong(opsLimit), memLimit) != 0 {
                 return nil
             }
             return output

--- a/Sodium/RandomBytes.swift
+++ b/Sodium/RandomBytes.swift
@@ -13,11 +13,10 @@ public class RandomBytes {
         if length < 0 {
             return nil
         }
-        let output = NSMutableData(length: length)
-        if output == nil {
+        guard let output = NSMutableData(length: length) else {
             return nil
         }
-        randombytes_buf(output!.mutableBytesPtr, output!.length)
+        randombytes_buf(output.mutableBytesPtr, output.length)
         return output
     }
     

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -18,29 +18,25 @@ public class SecretBox {
     public typealias MAC = NSData
     
     public func key() -> Key? {
-        let k = NSMutableData(length: KeyBytes)
-        if k == nil {
+        guard let k = NSMutableData(length: KeyBytes) else {
             return nil
         }
-        randombytes_buf(k!.mutableBytesPtr, k!.length)
+        randombytes_buf(k.mutableBytesPtr, k.length)
         return k
     }
     
     public func nonce() -> Nonce? {
-        let n = NSMutableData(length: NonceBytes)
-        if n == nil {
+        guard let n = NSMutableData(length: NonceBytes) else {
             return nil
         }
-        randombytes_buf(n!.mutableBytesPtr, n!.length)
+        randombytes_buf(n.mutableBytesPtr, n.length)
         return n
     }
     
     public func seal(message: NSData, secretKey: Key) -> NSData? {
-        let sealed: (NSData, Nonce)? = seal(message, secretKey: secretKey)
-        if sealed == nil {
+        guard let (authenticatedCipherText, nonce): (NSData, Nonce) = seal(message, secretKey: secretKey) else {
             return nil
         }
-        let (authenticatedCipherText, nonce) = sealed!
         let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce)
         nonceAndAuthenticatedCipherText.appendData(authenticatedCipherText)
         return nonceAndAuthenticatedCipherText
@@ -50,48 +46,42 @@ public class SecretBox {
         if secretKey.length != KeyBytes {
             return nil
         }
-        let authenticatedCipherText = NSMutableData(length: message.length + MacBytes)
-        if authenticatedCipherText == nil {
+        guard let authenticatedCipherText = NSMutableData(length: message.length + MacBytes) else {
             return nil
         }
-        let nonce = self.nonce()
-        if nonce == nil {
+        guard let nonce = self.nonce() else {
             return nil
         }
-        if crypto_secretbox_easy(authenticatedCipherText!.mutableBytesPtr, message.bytesPtr, UInt64(message.length), nonce!.bytesPtr, secretKey.bytesPtr) != 0 {
+        if crypto_secretbox_easy(authenticatedCipherText.mutableBytesPtr, message.bytesPtr, UInt64(message.length), nonce.bytesPtr, secretKey.bytesPtr) != 0 {
             return nil
         }
-        return (authenticatedCipherText: authenticatedCipherText!, nonce: nonce!)
+        return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
     }
     
     public func seal(message: NSData, secretKey: Key) -> (cipherText: NSData, nonce: Nonce, mac: MAC)? {
         if secretKey.length != KeyBytes {
             return nil
         }
-        let cipherText = NSMutableData(length: message.length)
-        if cipherText == nil {
+        guard let cipherText = NSMutableData(length: message.length) else {
             return nil
         }
-        let mac = NSMutableData(length: MacBytes)
-        if mac == nil {
+        guard let mac = NSMutableData(length: MacBytes) else {
             return nil
         }
-        let nonce = self.nonce()
-        if nonce == nil {
+        guard let nonce = self.nonce() else {
             return nil
         }
-        if crypto_secretbox_detached(cipherText!.mutableBytesPtr, mac!.mutableBytesPtr, message.bytesPtr, UInt64(message.length), nonce!.bytesPtr, secretKey.bytesPtr) != 0 {
+        if crypto_secretbox_detached(cipherText.mutableBytesPtr, mac.mutableBytesPtr, message.bytesPtr, UInt64(message.length), nonce.bytesPtr, secretKey.bytesPtr) != 0 {
             return nil
         }
-        return (cipherText: cipherText!, nonce: nonce!, mac: mac!)
+        return (cipherText: cipherText, nonce: nonce, mac: mac)
     }
     
     public func open(nonceAndAuthenticatedCipherText: NSData, secretKey: Key) -> NSData? {
         if nonceAndAuthenticatedCipherText.length < MacBytes + NonceBytes {
             return nil
         }
-        let message = NSMutableData(length: nonceAndAuthenticatedCipherText.length - MacBytes - NonceBytes)
-        if message == nil {
+        guard let _ = NSMutableData(length: nonceAndAuthenticatedCipherText.length - MacBytes - NonceBytes) else {
             return nil
         }
         let nonce = nonceAndAuthenticatedCipherText.subdataWithRange(NSRange(0..<NonceBytes)) as Nonce
@@ -103,11 +93,10 @@ public class SecretBox {
         if authenticatedCipherText.length < MacBytes {
             return nil
         }
-        let message = NSMutableData(length: authenticatedCipherText.length - MacBytes)
-        if message == nil {
+        guard let message = NSMutableData(length: authenticatedCipherText.length - MacBytes) else {
             return nil
         }
-        if crypto_secretbox_open_easy(message!.mutableBytesPtr, authenticatedCipherText.bytesPtr, UInt64(authenticatedCipherText.length), nonce.bytesPtr, secretKey.bytesPtr) != 0 {
+        if crypto_secretbox_open_easy(message.mutableBytesPtr, authenticatedCipherText.bytesPtr, UInt64(authenticatedCipherText.length), nonce.bytesPtr, secretKey.bytesPtr) != 0 {
             return nil
         }
         return message
@@ -120,11 +109,10 @@ public class SecretBox {
         if secretKey.length != KeyBytes {
             return nil
         }
-        let message = NSMutableData(length: cipherText.length)
-        if message == nil {
+        guard let message = NSMutableData(length: cipherText.length) else {
             return nil
         }
-        if crypto_secretbox_open_detached(message!.mutableBytesPtr, cipherText.bytesPtr, mac.bytesPtr, UInt64(cipherText.length), nonce.bytesPtr, secretKey.bytesPtr) != 0 {
+        if crypto_secretbox_open_detached(message.mutableBytesPtr, cipherText.bytesPtr, mac.bytesPtr, UInt64(cipherText.length), nonce.bytesPtr, secretKey.bytesPtr) != 0 {
             return nil
         }
         return message

--- a/Sodium/ShortHash.swift
+++ b/Sodium/ShortHash.swift
@@ -16,11 +16,10 @@ public class ShortHash {
         if key.length != KeyBytes {
             return nil
         }
-        let output = NSMutableData(length: Bytes)
-        if output == nil {
+        guard let output = NSMutableData(length: Bytes) else {
             return nil
         }
-        if crypto_shorthash(output!.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), key.bytesPtr) != 0 {
+        if crypto_shorthash(output.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), key.bytesPtr) != 0 {
             return nil
         }
         return output

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -24,47 +24,42 @@ public class Sign {
     }
     
     public func keyPair() -> KeyPair? {
-        let pk = NSMutableData(length: PublicKeyBytes)
-        if pk == nil {
+        guard let pk = NSMutableData(length: PublicKeyBytes) else {
             return nil
         }
-        let sk = NSMutableData(length: SecretKeyBytes)
-        if sk == nil {
+        guard let sk = NSMutableData(length: SecretKeyBytes) else {
             return nil
         }
-        if crypto_sign_keypair(pk!.mutableBytesPtr, sk!.mutableBytesPtr) != 0 {
+        if crypto_sign_keypair(pk.mutableBytesPtr, sk.mutableBytesPtr) != 0 {
             return nil
         }
-        return KeyPair(publicKey: PublicKey(data: pk!), secretKey: SecretKey(data: sk!))
+        return KeyPair(publicKey: PublicKey(data: pk), secretKey: SecretKey(data: sk))
     }
     
     public func keyPair(seed seed: NSData) -> KeyPair? {
         if seed.length != SeedBytes {
             return nil
         }
-        let pk = NSMutableData(length: PublicKeyBytes)
-        if pk == nil {
+        guard let pk = NSMutableData(length: PublicKeyBytes) else {
             return nil
         }
-        let sk = NSMutableData(length: SecretKeyBytes)
-        if sk == nil {
+        guard let sk = NSMutableData(length: SecretKeyBytes) else {
             return nil
         }
-        if crypto_sign_seed_keypair(pk!.mutableBytesPtr, sk!.mutableBytesPtr, seed.bytesPtr) != 0 {
+        if crypto_sign_seed_keypair(pk.mutableBytesPtr, sk.mutableBytesPtr, seed.bytesPtr) != 0 {
             return nil
         }
-        return KeyPair(publicKey: PublicKey(data: pk!), secretKey: SecretKey(data: sk!))
+        return KeyPair(publicKey: PublicKey(data: pk), secretKey: SecretKey(data: sk))
     }
     
     public func sign(message: NSData, secretKey: SecretKey) -> NSData? {
         if secretKey.length != SecretKeyBytes {
             return nil
         }
-        let signedMessage = NSMutableData(length: message.length + Bytes)
-        if signedMessage == nil {
+        guard let signedMessage = NSMutableData(length: message.length + Bytes) else {
             return nil
         }
-        if crypto_sign(signedMessage!.mutableBytesPtr, nil, message.bytesPtr, CUnsignedLongLong(message.length), secretKey.bytesPtr) != 0 {
+        if crypto_sign(signedMessage.mutableBytesPtr, nil, message.bytesPtr, CUnsignedLongLong(message.length), secretKey.bytesPtr) != 0 {
             return nil
         }
         return signedMessage
@@ -74,11 +69,10 @@ public class Sign {
         if secretKey.length != SecretKeyBytes {
             return nil
         }
-        let signature = NSMutableData(length: Bytes)
-        if signature == nil {
+        guard let signature = NSMutableData(length: Bytes) else {
             return nil
         }
-        if crypto_sign_detached(signature!.mutableBytesPtr, nil, message.bytesPtr, CUnsignedLongLong(message.length), secretKey.bytesPtr) != 0 {
+        if crypto_sign_detached(signature.mutableBytesPtr, nil, message.bytesPtr, CUnsignedLongLong(message.length), secretKey.bytesPtr) != 0 {
             return nil
         }
         return signature
@@ -101,12 +95,11 @@ public class Sign {
         if publicKey.length != PublicKeyBytes || signedMessage.length < Bytes {
             return nil
         }
-        let message = NSMutableData(length: signedMessage.length - Bytes)
-        if message == nil {
+        guard let message = NSMutableData(length: signedMessage.length - Bytes) else {
             return nil
         }
         var mlen: CUnsignedLongLong = 0;
-        if crypto_sign_open(message!.mutableBytesPtr, &mlen, signedMessage.bytesPtr, CUnsignedLongLong(signedMessage.length), publicKey.bytesPtr) != 0 {
+        if crypto_sign_open(message.mutableBytesPtr, &mlen, signedMessage.bytesPtr, CUnsignedLongLong(signedMessage.length), publicKey.bytesPtr) != 0 {
             return nil
         }
         return message

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -31,34 +31,31 @@ public class Utils {
     }
     
     public func bin2hex(bin: NSData) -> String? {
-        let hexData = NSMutableData(length: bin.length * 2 + 1)
-        if hexData == nil {
+        guard let hexData = NSMutableData(length: bin.length * 2 + 1) else {
             return nil
         }
-        let hexDataBytes = UnsafeMutablePointer<CChar>(hexData!.mutableBytes)
-        if sodium_bin2hex(hexDataBytes, hexData!.length, bin.bytesPtr, bin.length) == nil {
+        let hexDataBytes = UnsafeMutablePointer<CChar>(hexData.mutableBytes)
+        if sodium_bin2hex(hexDataBytes, hexData.length, bin.bytesPtr, bin.length) == nil {
             return nil
         }
         return String.fromCString(hexDataBytes)
     }
     
     public func hex2bin(hex: String, ignore: String? = nil) -> NSData? {
-        let hexData = hex.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
-        if hexData == nil {
+        guard let hexData = hex.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false) else {
             return nil
         }
-        let hexDataLen = hexData!.length
+        let hexDataLen = hexData.length
         let binDataCapacity = hexDataLen / 2
-        let binData = NSMutableData(length: binDataCapacity)
-        if binData == nil {
+        guard let binData = NSMutableData(length: binDataCapacity) else {
             return nil
         }
         var binDataLen: size_t = 0
         let ignore_cstr = ignore != nil ? (ignore! as NSString).UTF8String : nil
-        if sodium_hex2bin(binData!.mutableBytesPtr, binDataCapacity,UnsafePointer<CChar>(hexData!.bytes), hexDataLen, ignore_cstr, &binDataLen, nil) != 0 {
+        if sodium_hex2bin(binData.mutableBytesPtr, binDataCapacity,UnsafePointer<CChar>(hexData.bytes), hexDataLen, ignore_cstr, &binDataLen, nil) != 0 {
             return nil
         }
-        binData!.length = Int(binDataLen)
+        binData.length = Int(binDataLen)
         return binData
     }
 }


### PR DESCRIPTION
Swift 2 introduced the guard keyword which can be used to early exits.
Adopting it makes the code a little bit cleaner (although less cheerful, without all the exclamation marks :)