### PR TITLE
Changes `InternalExtensions` to `NSData+Extensions`

### DIFF
--- a/Sodium.xcodeproj/project.pbxproj
+++ b/Sodium.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		038365151A5A51D20081136D /* SecretBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038365141A5A51D20081136D /* SecretBox.swift */; };
 		091C7CDA1A507E95002E5351 /* ShortHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 091C7CD91A507E95002E5351 /* ShortHash.swift */; };
 		091C7CDC1A50839D002E5351 /* Sign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 091C7CDB1A50839D002E5351 /* Sign.swift */; };
-		092D181A1A5BF5A700972F77 /* InternalExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092D18191A5BF5A700972F77 /* InternalExtensions.swift */; };
+		092D181A1A5BF5A700972F77 /* NSData+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092D18191A5BF5A700972F77 /* NSData+Extensions.swift */; };
 		094E49401BE6C7760053AC01 /* crypto_aead_aes256gcm.h in Headers */ = {isa = PBXBuildFile; fileRef = 094E493F1BE6C7760053AC01 /* crypto_aead_aes256gcm.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		094E49411BE6C7D00053AC01 /* crypto_aead_aes256gcm.h in Headers */ = {isa = PBXBuildFile; fileRef = 094E493F1BE6C7760053AC01 /* crypto_aead_aes256gcm.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		094F21EA1A5017CA001C3141 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F21E91A5017CA001C3141 /* Box.swift */; };
@@ -150,7 +150,7 @@
 		90C75EE51AE3583E00F1E749 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F21E91A5017CA001C3141 /* Box.swift */; };
 		90C75EE61AE3583E00F1E749 /* SecretBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038365141A5A51D20081136D /* SecretBox.swift */; };
 		90C75EE71AE3583E00F1E749 /* GenericHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D80561A4ED0B4000B83F9 /* GenericHash.swift */; };
-		90C75EE81AE3583E00F1E749 /* InternalExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092D18191A5BF5A700972F77 /* InternalExtensions.swift */; };
+		90C75EE81AE3583E00F1E749 /* NSData+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092D18191A5BF5A700972F77 /* NSData+Extensions.swift */; };
 		90C75EE91AE3583E00F1E749 /* RandomBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D805A1A4F35CA000B83F9 /* RandomBytes.swift */; };
 		90C75EEA1AE3583E00F1E749 /* ShortHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 091C7CD91A507E95002E5351 /* ShortHash.swift */; };
 		90C75EEB1AE3583E00F1E749 /* Sign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 091C7CDB1A50839D002E5351 /* Sign.swift */; };
@@ -187,7 +187,7 @@
 		038365141A5A51D20081136D /* SecretBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecretBox.swift; sourceTree = "<group>"; };
 		091C7CD91A507E95002E5351 /* ShortHash.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortHash.swift; sourceTree = "<group>"; };
 		091C7CDB1A50839D002E5351 /* Sign.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sign.swift; sourceTree = "<group>"; };
-		092D18191A5BF5A700972F77 /* InternalExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalExtensions.swift; sourceTree = "<group>"; };
+		092D18191A5BF5A700972F77 /* NSData+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSData+Extensions.swift"; sourceTree = "<group>"; };
 		094E493F1BE6C7760053AC01 /* crypto_aead_aes256gcm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_aead_aes256gcm.h; sourceTree = "<group>"; };
 		094F21E91A5017CA001C3141 /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		095D80541A4ECCD7000B83F9 /* Sodium.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sodium.swift; sourceTree = "<group>"; };
@@ -372,7 +372,7 @@
 				038365141A5A51D20081136D /* SecretBox.swift */,
 				095D80561A4ED0B4000B83F9 /* GenericHash.swift */,
 				097F20D91AF127480088C2FE /* PWHash.swift */,
-				092D18191A5BF5A700972F77 /* InternalExtensions.swift */,
+				092D18191A5BF5A700972F77 /* NSData+Extensions.swift */,
 				095D805A1A4F35CA000B83F9 /* RandomBytes.swift */,
 				091C7CD91A507E95002E5351 /* ShortHash.swift */,
 				091C7CDB1A50839D002E5351 /* Sign.swift */,
@@ -949,7 +949,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				095D80551A4ECCD7000B83F9 /* Sodium.swift in Sources */,
-				092D181A1A5BF5A700972F77 /* InternalExtensions.swift in Sources */,
+				092D181A1A5BF5A700972F77 /* NSData+Extensions.swift in Sources */,
 				097F20DA1AF127480088C2FE /* PWHash.swift in Sources */,
 				038365151A5A51D20081136D /* SecretBox.swift in Sources */,
 				095D805D1A4F4F72000B83F9 /* Utils.swift in Sources */,
@@ -1012,7 +1012,7 @@
 				90C75EE61AE3583E00F1E749 /* SecretBox.swift in Sources */,
 				CFD847281BA8120900B1260F /* PWHash.swift in Sources */,
 				90C75EE71AE3583E00F1E749 /* GenericHash.swift in Sources */,
-				90C75EE81AE3583E00F1E749 /* InternalExtensions.swift in Sources */,
+				90C75EE81AE3583E00F1E749 /* NSData+Extensions.swift in Sources */,
 				90C75EE91AE3583E00F1E749 /* RandomBytes.swift in Sources */,
 				90C75EEA1AE3583E00F1E749 /* ShortHash.swift in Sources */,
 				90C75EEB1AE3583E00F1E749 /* Sign.swift in Sources */,

--- a/Sodium/NSData+Extensions.swift
+++ b/Sodium/NSData+Extensions.swift
@@ -8,13 +8,13 @@
 
 import Foundation
 
-extension NSData {
+public extension NSData {
     var bytesPtr: UnsafePointer<UInt8> {
         return UnsafePointer<UInt8>(self.bytes)
     }
 }
 
-extension NSMutableData {
+public extension NSMutableData {
     var mutableBytesPtr: UnsafeMutablePointer<UInt8> {
         return UnsafeMutablePointer<UInt8>(self.mutableBytes)
     }


### PR DESCRIPTION
- The NSData and NSMutableData are now public (That's why I renamed the
  file)
- With this change, whenever we need to extend the lib, we can use the
  same methods as Sodium to access the data pointers instead needing to
  duplicate this code.