### PR TITLE
Fix swift code in password hashing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,14 @@ Using Argon2i:
 
 ```swift
 let sodium = Sodium()!
-let password = "Correct Horse Battery Staple".toData()!
-let hashedStr = sodium.pwHash.str(password,
-  opsLimit: sodium.pwHash.OpsLimitInteractive,
-  memLimit: sodium.pwHash.MemLimitInteractive)!
+let password = "Correct Horse Battery Staple".dataUsingEncoding(NSUTF8StringEncoding)!
+let hashedStr = sodium.pwHash.scrypt.str(password,
+  opsLimit: sodium.pwHash.scrypt.OpsLimitInteractive,
+  memLimit: sodium.pwHash.scrypt.MemLimitInteractive)!
 
-if sodium.pwHash.strVerify(hashStr, passwd: password) == false {
+if sodium.pwHash.scrypt.strVerify(hashStr, passwd: password) {
+  // Password matches the given hash string
+} else {
   // Password doesn't match the given hash string
 }
 ```


### PR DESCRIPTION
`.toData()` isn't implemented on `String` and `.scrypt` was missing from `sodium.pwHash.*`

Using it like this seems to work fine 😊