### PR TITLE
Add public initializers to KeyPair structs

### DIFF
--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -27,6 +27,11 @@ public class Box {
     public struct KeyPair {
         public let publicKey: PublicKey
         public let secretKey: SecretKey
+
+		public init(publicKey: PublicKey, secretKey: SecretKey) {
+			self.publicKey = publicKey
+			self.secretKey = secretKey
+		}
     }
     
     public func keyPair() -> KeyPair? {

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -21,6 +21,11 @@ public class Sign {
     public struct KeyPair {
         public let publicKey: PublicKey
         public let secretKey: SecretKey
+
+		public init(publicKey: PublicKey, secretKey: SecretKey) {
+			self.publicKey = publicKey
+			self.secretKey = secretKey
+		}
     }
     
     public func keyPair() -> KeyPair? {


### PR DESCRIPTION
In this case, I find Swift's access levels a bit confusing. The implicitly created (or "default") initializer has the access level `internal` and can therefore not be used outside of the library, even though all members and the `struct` is marked as `public`.
This is not a real issue as the Sodium API takes `PublicKey` or `SecretKey` instances rather than `KeyPair`s. But it would be nice to be able to re-use the `KeyPair` struct after persisting keys without the need to extend it manually.

> A default initializer has the same access level as the type it initializes, unless that type is defined as `public`. For a type that is defined as `public`, the default initializer is considered internal. If you want a public type to be initializable with a no-argument initializer when used in another module, you must explicitly provide a public no-argument initializer yourself as part of the type’s definition.

— [The Swift Programming Language / Access Control / Initializers](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/AccessControl.html#//apple_ref/doc/uid/TP40014097-CH41-ID20)