### PR TITLE
Fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Secret-key authenticated encryption
 ===================================
 
 ```swift
+let sodium = Sodium()!
 let message = "My Test Message".dataUsingEncoding(NSUTF8StringEncoding)!
 let secretKey = sodium.secretBox.key()!
 let encrypted: NSData = sodium.secretBox.seal(message, secretKey: secretKey)!
@@ -212,6 +213,7 @@ Zeroing memory
 --------------
 
 ```swift
+let sodium = Sodium()!
 var dataToZero: NSMutableData
 sodium.utils.zero(dataToZero)
 ```
@@ -220,6 +222,7 @@ Constant-time comparison
 ------------------------
 
 ```swift
+let sodium = Sodium()!
 let secret1: NSData
 let secret2: NSData
 let equality = sodium.utils.equals(secret1, secret2)
@@ -229,6 +232,7 @@ Constant-time hexadecimal encoding
 ----------------------------------
 
 ```swift
+let sodium = Sodium()!
 let data: NSData
 let hex = sodium.utils.bin2hex(data)
 ```
@@ -237,6 +241,7 @@ Hexadecimal decoding
 --------------------
 
 ```swift
+let sodium = Sodium()!
 let data1 = sodium.utils.hex2bin("deadbeef")
 let data2 = sodium.utils.hex2bin("de:ad be:ef", ignore: " :")
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ let aliceKeyPair = sodium.box.keyPair()!
 let bobKeyPair = sodium.box.keyPair()!
 let message = "My Test Message".dataUsingEncoding(NSUTF8StringEncoding)!
 
-let encryptedMessageFromAliceToBob =
+let encryptedMessageFromAliceToBob: NSData =
   sodium.box.seal(message,
                   recipientPublicKey: bobKeyPair.publicKey,
                   senderSecretKey: aliceKeyPair.secretKey)!
@@ -126,7 +126,7 @@ Secret-key authenticated encryption
 ```swift
 let message = "My Test Message".dataUsingEncoding(NSUTF8StringEncoding)!
 let secretKey = sodium.secretBox.key()!
-let encrypted = sodium.secretBox.seal(message, secretKey: secretKey)!
+let encrypted: NSData = sodium.secretBox.seal(message, secretKey: secretKey)!
 if let decrypted = sodium.secretBox.open(encrypted, secretKey: secretKey) {
   // authenticator is valid, decrypted contains the original message
 }


### PR DESCRIPTION
Sorry, I actually broke the examples in a7942cbbf3e4046296951dd6ae8bb150c2ab73db.

I missed that some methods have ambiguous return types, for which the type can not be inferred automatically. Fixed that by specifying the actual expected return type.

Additionally I added initialization calls to each example code snippet to ease copy-paste from examples and make them more uniform.