### PR TITLE
Fix Swift 3 compiler errors

### DIFF
--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -72,7 +72,7 @@ public class Box {
     }
     
     public func seal(message: NSData, recipientPublicKey: PublicKey, senderSecretKey: SecretKey) -> NSData? {
-        guard let (authenticatedCipherText, nonce): (NSData, Nonce) = seal(message, recipientPublicKey: recipientPublicKey, senderSecretKey: senderSecretKey) else {
+        guard let (authenticatedCipherText, nonce): (NSData, Nonce) = seal(message: message, recipientPublicKey: recipientPublicKey, senderSecretKey: senderSecretKey) else {
             return nil
         }
         let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce as Data)
@@ -186,7 +186,7 @@ public class Box {
         }
         let nonce = nonceAndAuthenticatedCipherText.subdata(with: NSRange(0..<NonceBytes)) as Nonce
         let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdata(with: NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length))
-        return open(authenticatedCipherText, beforenm: beforenm, nonce: nonce)
+        return  open(authenticatedCipherText: authenticatedCipherText, beforenm: beforenm, nonce: nonce)
     }
 
     public func open(authenticatedCipherText: NSData, beforenm: Beforenm, nonce: Nonce) -> NSData? {
@@ -206,7 +206,7 @@ public class Box {
     }
 
     public func seal(message: NSData, beforenm: Beforenm) -> NSData? {
-        guard let (authenticatedCipherText, nonce): (NSData, Nonce) = seal(message, beforenm: beforenm) else {
+        guard let (authenticatedCipherText, nonce): (NSData, Nonce) = seal(message: message, beforenm: beforenm) else {
             return nil
         }
         let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce as Data)

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -14,7 +14,7 @@ public class Box {
     public let SecretKeyBytes = Int(crypto_box_secretkeybytes())
     public let NonceBytes = Int(crypto_box_noncebytes())
     public let MacBytes = Int(crypto_box_macbytes())
-    public let Primitive = String.fromCString(crypto_box_primitive())
+    public let Primitive = String.init(validatingUTF8:crypto_box_primitive())
     public let BeforenmBytes = Int(crypto_box_beforenmbytes())
     public let SealBytes = Int(crypto_box_sealbytes())
     

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -119,8 +119,8 @@ public class Box {
         if nonceAndAuthenticatedCipherText.length < NonceBytes + MacBytes {
             return nil
         }
-        let nonce = nonceAndAuthenticatedCipherText.subdataWithRange(NSRange(0..<NonceBytes)) as Nonce
-        let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdataWithRange(NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length))
+        let nonce = nonceAndAuthenticatedCipherText.subdata(with: NSRange(0..<NonceBytes)) as Nonce
+        let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdata(with: NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length))
         return open(authenticatedCipherText, senderPublicKey: senderPublicKey, recipientSecretKey: recipientSecretKey, nonce: nonce)
     }
     
@@ -184,8 +184,8 @@ public class Box {
         if nonceAndAuthenticatedCipherText.length < NonceBytes + MacBytes {
             return nil
         }
-        let nonce = nonceAndAuthenticatedCipherText.subdataWithRange(NSRange(0..<NonceBytes)) as Nonce
-        let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdataWithRange(NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length))
+        let nonce = nonceAndAuthenticatedCipherText.subdata(with: NSRange(0..<NonceBytes)) as Nonce
+        let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdata(with: NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length))
         return open(authenticatedCipherText, beforenm: beforenm, nonce: nonce)
     }
 

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -121,7 +121,7 @@ public class Box {
         }
         let nonce = nonceAndAuthenticatedCipherText.subdata(with: NSRange(0..<NonceBytes)) as Nonce
         let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdata(with: NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length))
-        return open(authenticatedCipherText, senderPublicKey: senderPublicKey, recipientSecretKey: recipientSecretKey, nonce: nonce)
+        return open(authenticatedCipherText: authenticatedCipherText, senderPublicKey: senderPublicKey, recipientSecretKey: recipientSecretKey, nonce: nonce)
     }
     
     public func open(authenticatedCipherText: NSData, senderPublicKey: PublicKey, recipientSecretKey: SecretKey, nonce: Nonce) -> NSData? {

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -44,7 +44,7 @@ public class Box {
         if crypto_box_keypair(pk.mutableBytesPtr, sk.mutableBytesPtr) != 0 {
             return nil
         }
-        return KeyPair(publicKey: PublicKey(data: pk), secretKey: SecretKey(data: sk))
+        return KeyPair(publicKey: PublicKey(data: pk as Data), secretKey: SecretKey(data: sk as Data))
     }
     
     public func keyPair(seed seed: NSData) -> KeyPair? {
@@ -60,7 +60,7 @@ public class Box {
         if crypto_box_seed_keypair(pk.mutableBytesPtr, sk.mutableBytesPtr, seed.bytesPtr) != 0 {
             return nil
         }
-        return KeyPair(publicKey: PublicKey(data: pk), secretKey: SecretKey(data: sk))
+        return KeyPair(publicKey: PublicKey(data: pk as Data), secretKey: SecretKey(data: sk as Data))
     }
     
     public func nonce() -> Nonce? {
@@ -75,8 +75,8 @@ public class Box {
         guard let (authenticatedCipherText, nonce): (NSData, Nonce) = seal(message, recipientPublicKey: recipientPublicKey, senderSecretKey: senderSecretKey) else {
             return nil
         }
-        let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce)
-        nonceAndAuthenticatedCipherText.appendData(authenticatedCipherText)
+        let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce as Data)
+        nonceAndAuthenticatedCipherText.appendData(authenticatedCipherText as Data)
         return nonceAndAuthenticatedCipherText
     }
     
@@ -209,8 +209,8 @@ public class Box {
         guard let (authenticatedCipherText, nonce): (NSData, Nonce) = seal(message, beforenm: beforenm) else {
             return nil
         }
-        let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce)
-        nonceAndAuthenticatedCipherText.appendData(authenticatedCipherText)
+        let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce as Data)
+        nonceAndAuthenticatedCipherText.appendData(authenticatedCipherText as Data)
         return nonceAndAuthenticatedCipherText
     }
     

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -47,7 +47,7 @@ public class Box {
         return KeyPair(publicKey: PublicKey(data: pk as Data), secretKey: SecretKey(data: sk as Data))
     }
     
-    public func keyPair(seed seed: NSData) -> KeyPair? {
+    public func keyPair(seed: NSData) -> KeyPair? {
         if seed.length != SeedBytes {
             return nil
         }

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -120,7 +120,7 @@ public class Box {
             return nil
         }
         let nonce = nonceAndAuthenticatedCipherText.subdata(with: NSRange(0..<NonceBytes)) as Nonce
-        let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdata(with: NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length))
+        let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdata(with: NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length)) as NSData
         return open(authenticatedCipherText: authenticatedCipherText, senderPublicKey: senderPublicKey, recipientSecretKey: recipientSecretKey, nonce: nonce)
     }
     
@@ -185,7 +185,7 @@ public class Box {
             return nil
         }
         let nonce = nonceAndAuthenticatedCipherText.subdata(with: NSRange(0..<NonceBytes)) as Nonce
-        let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdata(with: NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length))
+        let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdata(with: NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length)) as NSData
         return  open(authenticatedCipherText: authenticatedCipherText, beforenm: beforenm, nonce: nonce)
     }
 

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -76,7 +76,7 @@ public class Box {
             return nil
         }
         let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce as Data)
-        nonceAndAuthenticatedCipherText.appendData(authenticatedCipherText as Data)
+        nonceAndAuthenticatedCipherText.append(authenticatedCipherText as Data)
         return nonceAndAuthenticatedCipherText
     }
     
@@ -210,7 +210,7 @@ public class Box {
             return nil
         }
         let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce as Data)
-        nonceAndAuthenticatedCipherText.appendData(authenticatedCipherText as Data)
+        nonceAndAuthenticatedCipherText.append(authenticatedCipherText as Data)
         return nonceAndAuthenticatedCipherText
     }
     

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -41,7 +41,7 @@ public class Box {
         guard let sk = NSMutableData(length: SecretKeyBytes) else {
             return nil
         }
-        if crypto_box_keypair(pk.mutableBytesPtr, sk.mutableBytesPtr) != 0 {
+        if crypto_box_keypair(pk.mutableBytesPtr(), sk.mutableBytesPtr()) != 0 {
             return nil
         }
         return KeyPair(publicKey: PublicKey(data: pk as Data), secretKey: SecretKey(data: sk as Data))
@@ -57,7 +57,7 @@ public class Box {
         guard let sk = NSMutableData(length: SecretKeyBytes) else {
             return nil
         }
-        if crypto_box_seed_keypair(pk.mutableBytesPtr, sk.mutableBytesPtr, seed.bytesPtr) != 0 {
+        if crypto_box_seed_keypair(pk.mutableBytesPtr(), sk.mutableBytesPtr(), seed.bytesPtr()) != 0 {
             return nil
         }
         return KeyPair(publicKey: PublicKey(data: pk as Data), secretKey: SecretKey(data: sk as Data))
@@ -67,7 +67,7 @@ public class Box {
         guard let nonce = NSMutableData(length: NonceBytes) else {
             return nil
         }
-        randombytes_buf(nonce.mutableBytesPtr, nonce.length)
+        randombytes_buf(nonce.mutableBytesPtr(), nonce.length)
         return nonce as Nonce
     }
     
@@ -90,7 +90,7 @@ public class Box {
         guard let nonce = self.nonce() else {
             return nil
         }
-        if crypto_box_easy(authenticatedCipherText.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), nonce.bytesPtr, recipientPublicKey.bytesPtr, senderSecretKey.bytesPtr) != 0 {
+        if crypto_box_easy(authenticatedCipherText.mutableBytesPtr(), message.bytesPtr(), CUnsignedLongLong(message.length), nonce.bytesPtr(), recipientPublicKey.bytesPtr(), senderSecretKey.bytesPtr()) != 0 {
             return nil
         }
         return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
@@ -109,7 +109,7 @@ public class Box {
         guard let nonce = self.nonce() else {
             return nil
         }
-        if crypto_box_detached(authenticatedCipherText.mutableBytesPtr, mac.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), nonce.bytesPtr, recipientPublicKey.bytesPtr, senderSecretKey.bytesPtr) != 0 {
+        if crypto_box_detached(authenticatedCipherText.mutableBytesPtr(), mac.mutableBytesPtr(), message.bytesPtr(), CUnsignedLongLong(message.length), nonce.bytesPtr(), recipientPublicKey.bytesPtr(), senderSecretKey.bytesPtr()) != 0 {
             return nil
         }
         return (authenticatedCipherText: authenticatedCipherText, nonce: nonce as Nonce, mac: mac as MAC)
@@ -134,7 +134,7 @@ public class Box {
         guard let message = NSMutableData(length: authenticatedCipherText.length - MacBytes) else {
             return nil
         }
-        if crypto_box_open_easy(message.mutableBytesPtr, authenticatedCipherText.bytesPtr, CUnsignedLongLong(authenticatedCipherText.length), nonce.bytesPtr, senderPublicKey.bytesPtr, recipientSecretKey.bytesPtr) != 0 {
+        if crypto_box_open_easy(message.mutableBytesPtr(), authenticatedCipherText.bytesPtr(), CUnsignedLongLong(authenticatedCipherText.length), nonce.bytesPtr(), senderPublicKey.bytesPtr(), recipientSecretKey.bytesPtr()) != 0 {
             return nil
         }
         return message
@@ -150,7 +150,7 @@ public class Box {
         guard let message = NSMutableData(length: authenticatedCipherText.length) else {
             return nil
         }
-        if crypto_box_open_detached(message.mutableBytesPtr, authenticatedCipherText.bytesPtr, mac.bytesPtr, CUnsignedLongLong(authenticatedCipherText.length), nonce.bytesPtr, senderPublicKey.bytesPtr, recipientSecretKey.bytesPtr) != 0 {
+        if crypto_box_open_detached(message.mutableBytesPtr(), authenticatedCipherText.bytesPtr(), mac.bytesPtr(), CUnsignedLongLong(authenticatedCipherText.length), nonce.bytesPtr(), senderPublicKey.bytesPtr(), recipientSecretKey.bytesPtr()) != 0 {
             return nil
         }
         return message
@@ -158,7 +158,7 @@ public class Box {
     
     public func beforenm(recipientPublicKey: PublicKey, senderSecretKey: SecretKey) -> NSData? {
         let key = NSMutableData(length: BeforenmBytes)
-        if crypto_box_beforenm(key!.mutableBytesPtr, recipientPublicKey.bytesPtr, senderSecretKey.bytesPtr) != 0 {
+        if crypto_box_beforenm(key!.mutableBytesPtr(), recipientPublicKey.bytesPtr(), senderSecretKey.bytesPtr()) != 0 {
             return nil
         }
         return key
@@ -174,7 +174,7 @@ public class Box {
         guard let nonce = self.nonce() else {
             return nil
         }
-        if crypto_box_easy_afternm(authenticatedCipherText.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), nonce.bytesPtr, beforenm.bytesPtr) != 0 {
+        if crypto_box_easy_afternm(authenticatedCipherText.mutableBytesPtr(), message.bytesPtr(), CUnsignedLongLong(message.length), nonce.bytesPtr(), beforenm.bytesPtr()) != 0 {
             return nil
         }
         return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
@@ -199,7 +199,7 @@ public class Box {
         guard let message = NSMutableData(length: authenticatedCipherText.length - MacBytes) else {
             return nil
         }
-        if crypto_box_open_easy_afternm(message.mutableBytesPtr, authenticatedCipherText.bytesPtr, CUnsignedLongLong(authenticatedCipherText.length), nonce.bytesPtr, beforenm.bytesPtr) != 0 {
+        if crypto_box_open_easy_afternm(message.mutableBytesPtr(), authenticatedCipherText.bytesPtr(), CUnsignedLongLong(authenticatedCipherText.length), nonce.bytesPtr(), beforenm.bytesPtr()) != 0 {
             return nil
         }
         return message
@@ -221,7 +221,7 @@ public class Box {
         guard let anonymousCipherText = NSMutableData(length: SealBytes + message.length) else {
             return nil
         }
-        if crypto_box_seal(anonymousCipherText.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), recipientPublicKey.bytesPtr) != 0 {
+        if crypto_box_seal(anonymousCipherText.mutableBytesPtr(), message.bytesPtr(), CUnsignedLongLong(message.length), recipientPublicKey.bytesPtr()) != 0 {
             return nil
         }
         return anonymousCipherText
@@ -235,7 +235,7 @@ public class Box {
         if message == nil {
             return nil
         }
-        if crypto_box_seal_open(message!.mutableBytesPtr, anonymousCipherText.bytesPtr, CUnsignedLongLong(anonymousCipherText.length), recipientPublicKey.bytesPtr, recipientSecretKey.bytesPtr) != 0 {
+        if crypto_box_seal_open(message!.mutableBytesPtr(), anonymousCipherText.bytesPtr(), CUnsignedLongLong(anonymousCipherText.length), recipientPublicKey.bytesPtr(), recipientSecretKey.bytesPtr()) != 0 {
             return nil
         }
         return message

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -18,7 +18,7 @@ public class GenericHash {
     public let Primitive = String.fromCString(crypto_generichash_primitive())
     
     public func hash(message: NSData, key: NSData? = nil) -> NSData? {
-        return hash(message, key: key, outputLength: Bytes)
+        return hash(message: message, key: key, outputLength: Bytes)
     }
     
     public func hash(message: NSData, key: NSData?, outputLength: Int) -> NSData? {
@@ -38,7 +38,7 @@ public class GenericHash {
     }
 
     public func hash(message: NSData, outputLength: Int) -> NSData? {
-        return hash(message, key: NSData(), outputLength: outputLength)
+        return hash(message: message, key: NSData(), outputLength: outputLength)
     }
     
     public func initStream(key: NSData? = nil) -> Stream? {

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -15,7 +15,7 @@ public class GenericHash {
     public let KeybytesMin = Int(crypto_generichash_keybytes_min())
     public let KeybytesMax = Int(crypto_generichash_keybytes_max())
     public let Keybytes = Int(crypto_generichash_keybytes())
-    public let Primitive = String.fromCString(crypto_generichash_primitive())
+    public let Primitive = String.init(validatingUTF8:crypto_generichash_primitive())
     
     public func hash(message: NSData, key: NSData? = nil) -> NSData? {
         return hash(message: message, key: key, outputLength: Bytes)

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -58,7 +58,7 @@ public class GenericHash {
         private var state: UnsafeMutablePointer<crypto_generichash_state>?
 
         init?(key: NSData?, outputLength: Int) {
-            state = UnsafeMutablePointer<crypto_generichash_state>.alloc(1)
+            state = UnsafeMutablePointer<crypto_generichash_state>.allocate(capacity: 1)
             guard let state = state else {
                 return nil
             }
@@ -75,7 +75,7 @@ public class GenericHash {
         }
     
         deinit {
-            state?.dealloc(1)
+            state?.deallocate(capacity: 1)
         }
     
         public func update(input: NSData) -> Bool {

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -27,9 +27,9 @@ public class GenericHash {
         }
         var ret: CInt;
         if let key = key {
-            ret = crypto_generichash(output.mutableBytesPtr, output.length, message.bytesPtr, CUnsignedLongLong(message.length), key.bytesPtr, key.length)
+            ret = crypto_generichash(output.mutableBytesPtr(), output.length, message.bytesPtr(), CUnsignedLongLong(message.length), key.bytesPtr(), key.length)
         } else {
-            ret = crypto_generichash(output.mutableBytesPtr, output.length, message.bytesPtr, CUnsignedLongLong(message.length), nil, 0)
+            ret = crypto_generichash(output.mutableBytesPtr(), output.length, message.bytesPtr(), CUnsignedLongLong(message.length), nil, 0)
         }
         if ret != 0 {
             return nil
@@ -64,7 +64,7 @@ public class GenericHash {
             }
             var ret: CInt
             if let key = key {
-                ret = crypto_generichash_init(state, key.bytesPtr, key.length, outputLength)
+                ret = crypto_generichash_init(state, key.bytesPtr(), key.length, outputLength)
             } else {
                 ret = crypto_generichash_init(state, nil, 0, outputLength)
             }
@@ -79,14 +79,14 @@ public class GenericHash {
         }
     
         public func update(input: NSData) -> Bool {
-            return crypto_generichash_update(state!, input.bytesPtr, CUnsignedLongLong(input.length)) == 0
+            return crypto_generichash_update(state!, input.bytesPtr(), CUnsignedLongLong(input.length)) == 0
         }
     
         public func final() -> NSData? {
             guard let output = NSMutableData(length: outputLength) else {
                 return nil
             }
-            if crypto_generichash_final(state!, output.mutableBytesPtr, output.length) != 0 {
+            if crypto_generichash_final(state!, output.mutableBytesPtr(), output.length) != 0 {
                 return nil
             }
             return output

--- a/Sodium/NSData+Extensions.swift
+++ b/Sodium/NSData+Extensions.swift
@@ -8,14 +8,16 @@
 
 import Foundation
 
-public extension NSData {
-    var bytesPtr: UnsafePointer<UInt8> {
-        return UnsafePointer<UInt8>(self.bytes)
+public extension NSData {    
+    func bytesPtr<T>() -> UnsafePointer<T>{
+        let rawBytes = self.bytes
+        return rawBytes.assumingMemoryBound(to: T.self);
     }
 }
 
 public extension NSMutableData {
-    var mutableBytesPtr: UnsafeMutablePointer<UInt8> {
-        return UnsafeMutablePointer<UInt8>(self.mutableBytes)
+    func mutableBytesPtr<T>() -> UnsafeMutablePointer<T>{
+        let rawBytes = self.mutableBytes
+        return rawBytes.assumingMemoryBound(to: T.self)
     }
 }

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -33,7 +33,7 @@ public class PWHash {
         guard let hashData = (hash + "\0").data(using: String.Encoding.utf8, allowLossyConversion: false) else {
                 return false
         }
-        return crypto_pwhash_str_verify(UnsafePointer<CChar>(hashData.bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0
+        return crypto_pwhash_str_verify(UnsafePointer<CChar>((hashData as NSData).bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0
     }
 
     public func hash(outputLength: Int, passwd: NSData, salt: NSData, opsLimit: Int, memLimit: Int) -> NSData? {
@@ -74,7 +74,7 @@ public class PWHash {
             guard let hashData = (hash + "\0").data(using: String.Encoding.utf8, allowLossyConversion: false) else {
                 return false
             }
-            return crypto_pwhash_scryptsalsa208sha256_str_verify(UnsafePointer<CChar>(hashData.bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0
+            return crypto_pwhash_scryptsalsa208sha256_str_verify(UnsafePointer<CChar>((hashData as NSData).bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0
         }
 
         public func hash(outputLength: Int, passwd: NSData, salt: NSData, opsLimit: Int, memLimit: Int) -> NSData? {

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -23,8 +23,7 @@ public class PWHash {
         guard let output = NSMutableData(length: StrBytes) else {
             return nil
         }
-        let outputRawBytes = output.mutableBytes
-        if crypto_pwhash_str(outputRawBytes.assumingMemoryBound(to: CChar.self), passwd.bytesPtr(), CUnsignedLongLong(passwd.length), CUnsignedLongLong(opsLimit), size_t(memLimit)) != 0 {
+        if crypto_pwhash_str(output.mutableBytesPtr(), passwd.bytesPtr(), CUnsignedLongLong(passwd.length), CUnsignedLongLong(opsLimit), size_t(memLimit)) != 0 {
             return nil
         }
         return NSString(data: output as Data, encoding: String.Encoding.utf8.rawValue) as String?

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -30,7 +30,7 @@ public class PWHash {
     }
 
     public func strVerify(hash: String, passwd: NSData) -> Bool {
-        guard let hashData = (hash + "\0").data(using: NSUTF8StringEncoding, allowLossyConversion: false) else {
+        guard let hashData = (hash + "\0").data(using: String.Encoding.utf8, allowLossyConversion: false) else {
                 return false
         }
         return crypto_pwhash_str_verify(UnsafePointer<CChar>(hashData.bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0
@@ -71,7 +71,7 @@ public class PWHash {
         }
 
         public func strVerify(hash: String, passwd: NSData) -> Bool {
-            guard let hashData = (hash + "\0").data(using: NSUTF8StringEncoding, allowLossyConversion: false) else {
+            guard let hashData = (hash + "\0").data(using: String.Encoding.utf8, allowLossyConversion: false) else {
                 return false
             }
             return crypto_pwhash_scryptsalsa208sha256_str_verify(UnsafePointer<CChar>(hashData.bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -26,7 +26,7 @@ public class PWHash {
         if crypto_pwhash_str(UnsafeMutablePointer<CChar>(output.mutableBytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length), CUnsignedLongLong(opsLimit), size_t(memLimit)) != 0 {
             return nil
         }
-        return NSString(data: output, encoding: NSUTF8StringEncoding) as String?
+        return NSString(data: output as Data, encoding: String.Encoding.utf8.rawValue) as String?
     }
 
     public func strVerify(hash: String, passwd: NSData) -> Bool {
@@ -67,7 +67,7 @@ public class PWHash {
             if crypto_pwhash_scryptsalsa208sha256_str(UnsafeMutablePointer<CChar>(output.mutableBytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length), CUnsignedLongLong(opsLimit), size_t(memLimit)) != 0 {
                 return nil
             }
-            return NSString(data: output, encoding: NSUTF8StringEncoding) as String?
+            return NSString(data: output as Data, encoding: String.Encoding.utf8.rawValue) as String?
         }
 
         public func strVerify(hash: String, passwd: NSData) -> Bool {

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -23,7 +23,8 @@ public class PWHash {
         guard let output = NSMutableData(length: StrBytes) else {
             return nil
         }
-        if crypto_pwhash_str(UnsafeMutablePointer<CChar>(output.mutableBytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length), CUnsignedLongLong(opsLimit), size_t(memLimit)) != 0 {
+        let outputRawBytes = output.mutableBytes
+        if crypto_pwhash_str(outputRawBytes.assumingMemoryBound(to: CChar.self), passwd.bytesPtr(), CUnsignedLongLong(passwd.length), CUnsignedLongLong(opsLimit), size_t(memLimit)) != 0 {
             return nil
         }
         return NSString(data: output as Data, encoding: String.Encoding.utf8.rawValue) as String?
@@ -33,7 +34,7 @@ public class PWHash {
         guard let hashData = (hash + "\0").data(using: String.Encoding.utf8, allowLossyConversion: false) else {
                 return false
         }
-        return crypto_pwhash_str_verify(UnsafePointer<CChar>((hashData as NSData).bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0
+        return crypto_pwhash_str_verify((hashData as NSData).bytesPtr(), passwd.bytesPtr(), CUnsignedLongLong(passwd.length)) == 0
     }
 
     public func hash(outputLength: Int, passwd: NSData, salt: NSData, opsLimit: Int, memLimit: Int) -> NSData? {
@@ -43,7 +44,7 @@ public class PWHash {
         guard let output = NSMutableData(length: outputLength) else {
             return nil
         }
-        if crypto_pwhash(output.mutableBytesPtr, CUnsignedLongLong(outputLength), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length), salt.bytesPtr, CUnsignedLongLong(opsLimit), size_t(memLimit), crypto_pwhash_ALG_DEFAULT) != 0 {
+        if crypto_pwhash(output.mutableBytesPtr(), CUnsignedLongLong(outputLength), passwd.bytesPtr(), CUnsignedLongLong(passwd.length), salt.bytesPtr(), CUnsignedLongLong(opsLimit), size_t(memLimit), crypto_pwhash_ALG_DEFAULT) != 0 {
             return nil
         }
         return output
@@ -64,7 +65,7 @@ public class PWHash {
             guard let output = NSMutableData(length: StrBytes) else {
                 return nil
             }
-            if crypto_pwhash_scryptsalsa208sha256_str(UnsafeMutablePointer<CChar>(output.mutableBytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length), CUnsignedLongLong(opsLimit), size_t(memLimit)) != 0 {
+            if crypto_pwhash_scryptsalsa208sha256_str(output.mutableBytesPtr(), passwd.bytesPtr(), CUnsignedLongLong(passwd.length), CUnsignedLongLong(opsLimit), size_t(memLimit)) != 0 {
                 return nil
             }
             return NSString(data: output as Data, encoding: String.Encoding.utf8.rawValue) as String?
@@ -74,7 +75,7 @@ public class PWHash {
             guard let hashData = (hash + "\0").data(using: String.Encoding.utf8, allowLossyConversion: false) else {
                 return false
             }
-            return crypto_pwhash_scryptsalsa208sha256_str_verify(UnsafePointer<CChar>((hashData as NSData).bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0
+            return crypto_pwhash_scryptsalsa208sha256_str_verify((hashData as NSData).bytesPtr(), passwd.bytesPtr(), CUnsignedLongLong(passwd.length)) == 0
         }
 
         public func hash(outputLength: Int, passwd: NSData, salt: NSData, opsLimit: Int, memLimit: Int) -> NSData? {
@@ -84,7 +85,7 @@ public class PWHash {
             guard let output = NSMutableData(length: outputLength) else {
                 return nil
             }
-            if crypto_pwhash_scryptsalsa208sha256(output.mutableBytesPtr, CUnsignedLongLong(outputLength), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length), salt.bytesPtr, CUnsignedLongLong(opsLimit), size_t(memLimit)) != 0 {
+            if crypto_pwhash_scryptsalsa208sha256(output.mutableBytesPtr(), CUnsignedLongLong(outputLength), passwd.bytesPtr(), CUnsignedLongLong(passwd.length), salt.bytesPtr(), CUnsignedLongLong(opsLimit), size_t(memLimit)) != 0 {
                 return nil
             }
             return output

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -30,7 +30,7 @@ public class PWHash {
     }
 
     public func strVerify(hash: String, passwd: NSData) -> Bool {
-        guard let hashData = (hash + "\0").data(usingEncoding: NSUTF8StringEncoding, allowLossyConversion: false) else {
+        guard let hashData = (hash + "\0").data(using: NSUTF8StringEncoding, allowLossyConversion: false) else {
                 return false
         }
         return crypto_pwhash_str_verify(UnsafePointer<CChar>(hashData.bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0
@@ -71,7 +71,7 @@ public class PWHash {
         }
 
         public func strVerify(hash: String, passwd: NSData) -> Bool {
-            guard let hashData = (hash + "\0").data(usingEncoding: NSUTF8StringEncoding, allowLossyConversion: false) else {
+            guard let hashData = (hash + "\0").data(using: NSUTF8StringEncoding, allowLossyConversion: false) else {
                 return false
             }
             return crypto_pwhash_scryptsalsa208sha256_str_verify(UnsafePointer<CChar>(hashData.bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -30,7 +30,7 @@ public class PWHash {
     }
 
     public func strVerify(hash: String, passwd: NSData) -> Bool {
-        guard let hashData = (hash + "\0").dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false) else {
+        guard let hashData = (hash + "\0").data(usingEncoding: NSUTF8StringEncoding, allowLossyConversion: false) else {
                 return false
         }
         return crypto_pwhash_str_verify(UnsafePointer<CChar>(hashData.bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0
@@ -71,7 +71,7 @@ public class PWHash {
         }
 
         public func strVerify(hash: String, passwd: NSData) -> Bool {
-            guard let hashData = (hash + "\0").dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false) else {
+            guard let hashData = (hash + "\0").data(usingEncoding: NSUTF8StringEncoding, allowLossyConversion: false) else {
                 return false
             }
             return crypto_pwhash_scryptsalsa208sha256_str_verify(UnsafePointer<CChar>(hashData.bytes), UnsafePointer<CChar>(passwd.bytes), CUnsignedLongLong(passwd.length)) == 0

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -11,7 +11,7 @@ import Foundation
 public class PWHash {
     public let SaltBytes = Int(crypto_pwhash_saltbytes())
     public let StrBytes = Int(crypto_pwhash_strbytes()) - (1 as Int)
-    public let StrPrefix = String(UTF8String: crypto_pwhash_strprefix())
+    public let StrPrefix = String.init(validatingUTF8: crypto_pwhash_strprefix())
     public let OpsLimitInteractive = Int(crypto_pwhash_opslimit_interactive())
     public let OpsLimitModerate = Int(crypto_pwhash_opslimit_moderate())
     public let OpsLimitSensitive = Int(crypto_pwhash_opslimit_sensitive())
@@ -54,7 +54,7 @@ public class PWHash {
     public class SCrypt {
         public let SaltBytes = Int(crypto_pwhash_scryptsalsa208sha256_saltbytes())
         public let StrBytes = Int(crypto_pwhash_scryptsalsa208sha256_strbytes()) - (1 as Int)
-        public let StrPrefix = String(UTF8String: crypto_pwhash_scryptsalsa208sha256_strprefix())
+        public let StrPrefix = String.init(validatingUTF8: crypto_pwhash_scryptsalsa208sha256_strprefix())
         public let OpsLimitInteractive = Int(crypto_pwhash_scryptsalsa208sha256_opslimit_interactive())
         public let OpsLimitSensitive = Int(crypto_pwhash_scryptsalsa208sha256_opslimit_sensitive())
         public let MemLimitInteractive = Int(crypto_pwhash_scryptsalsa208sha256_memlimit_interactive())

--- a/Sodium/RandomBytes.swift
+++ b/Sodium/RandomBytes.swift
@@ -16,7 +16,7 @@ public class RandomBytes {
         guard let output = NSMutableData(length: length) else {
             return nil
         }
-        randombytes_buf(output.mutableBytesPtr, output.length)
+        randombytes_buf(output.mutableBytesPtr(), output.length)
         return output
     }
     

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -85,7 +85,7 @@ public class SecretBox {
             return nil
         }
         let nonce = nonceAndAuthenticatedCipherText.subdata(with: NSRange(0..<NonceBytes)) as Nonce
-        let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdata(with: NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length))
+        let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdata(with: NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length)) as NSData
         return open(authenticatedCipherText: authenticatedCipherText, secretKey: secretKey, nonce: nonce)
     }
     

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -21,7 +21,7 @@ public class SecretBox {
         guard let k = NSMutableData(length: KeyBytes) else {
             return nil
         }
-        randombytes_buf(k.mutableBytesPtr, k.length)
+        randombytes_buf(k.mutableBytesPtr(), k.length)
         return k
     }
     
@@ -29,7 +29,7 @@ public class SecretBox {
         guard let n = NSMutableData(length: NonceBytes) else {
             return nil
         }
-        randombytes_buf(n.mutableBytesPtr, n.length)
+        randombytes_buf(n.mutableBytesPtr(), n.length)
         return n
     }
     
@@ -52,7 +52,7 @@ public class SecretBox {
         guard let nonce = self.nonce() else {
             return nil
         }
-        if crypto_secretbox_easy(authenticatedCipherText.mutableBytesPtr, message.bytesPtr, UInt64(message.length), nonce.bytesPtr, secretKey.bytesPtr) != 0 {
+        if crypto_secretbox_easy(authenticatedCipherText.mutableBytesPtr(), message.bytesPtr(), UInt64(message.length), nonce.bytesPtr(), secretKey.bytesPtr()) != 0 {
             return nil
         }
         return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
@@ -71,7 +71,7 @@ public class SecretBox {
         guard let nonce = self.nonce() else {
             return nil
         }
-        if crypto_secretbox_detached(cipherText.mutableBytesPtr, mac.mutableBytesPtr, message.bytesPtr, UInt64(message.length), nonce.bytesPtr, secretKey.bytesPtr) != 0 {
+        if crypto_secretbox_detached(cipherText.mutableBytesPtr(), mac.mutableBytesPtr(), message.bytesPtr(), UInt64(message.length), nonce.bytesPtr(), secretKey.bytesPtr()) != 0 {
             return nil
         }
         return (cipherText: cipherText, nonce: nonce, mac: mac)
@@ -96,7 +96,7 @@ public class SecretBox {
         guard let message = NSMutableData(length: authenticatedCipherText.length - MacBytes) else {
             return nil
         }
-        if crypto_secretbox_open_easy(message.mutableBytesPtr, authenticatedCipherText.bytesPtr, UInt64(authenticatedCipherText.length), nonce.bytesPtr, secretKey.bytesPtr) != 0 {
+        if crypto_secretbox_open_easy(message.mutableBytesPtr(), authenticatedCipherText.bytesPtr(), UInt64(authenticatedCipherText.length), nonce.bytesPtr(), secretKey.bytesPtr()) != 0 {
             return nil
         }
         return message
@@ -112,7 +112,7 @@ public class SecretBox {
         guard let message = NSMutableData(length: cipherText.length) else {
             return nil
         }
-        if crypto_secretbox_open_detached(message.mutableBytesPtr, cipherText.bytesPtr, mac.bytesPtr, UInt64(cipherText.length), nonce.bytesPtr, secretKey.bytesPtr) != 0 {
+        if crypto_secretbox_open_detached(message.mutableBytesPtr(), cipherText.bytesPtr(), mac.bytesPtr(), UInt64(cipherText.length), nonce.bytesPtr(), secretKey.bytesPtr()) != 0 {
             return nil
         }
         return message

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -84,8 +84,8 @@ public class SecretBox {
         guard let _ = NSMutableData(length: nonceAndAuthenticatedCipherText.length - MacBytes - NonceBytes) else {
             return nil
         }
-        let nonce = nonceAndAuthenticatedCipherText.subdataWithRange(NSRange(0..<NonceBytes)) as Nonce
-        let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdataWithRange(NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length))
+        let nonce = nonceAndAuthenticatedCipherText.subdata(with: NSRange(0..<NonceBytes)) as Nonce
+        let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdata(with: NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length))
         return open(authenticatedCipherText: authenticatedCipherText, secretKey: secretKey, nonce: nonce)
     }
     

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -34,7 +34,7 @@ public class SecretBox {
     }
     
     public func seal(message: NSData, secretKey: Key) -> NSData? {
-        guard let (authenticatedCipherText, nonce): (NSData, Nonce) = seal(message, secretKey: secretKey) else {
+        guard let (authenticatedCipherText, nonce): (NSData, Nonce) = seal(message: message, secretKey: secretKey) else {
             return nil
         }
         let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce)
@@ -86,7 +86,7 @@ public class SecretBox {
         }
         let nonce = nonceAndAuthenticatedCipherText.subdataWithRange(NSRange(0..<NonceBytes)) as Nonce
         let authenticatedCipherText = nonceAndAuthenticatedCipherText.subdataWithRange(NSRange(NonceBytes..<nonceAndAuthenticatedCipherText.length))
-        return open(authenticatedCipherText, secretKey: secretKey, nonce: nonce)
+        return open(authenticatedCipherText: authenticatedCipherText, secretKey: secretKey, nonce: nonce)
     }
     
     public func open(authenticatedCipherText: NSData, secretKey: Key, nonce: Nonce) -> NSData? {

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -37,8 +37,8 @@ public class SecretBox {
         guard let (authenticatedCipherText, nonce): (NSData, Nonce) = seal(message: message, secretKey: secretKey) else {
             return nil
         }
-        let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce)
-        nonceAndAuthenticatedCipherText.appendData(authenticatedCipherText)
+        let nonceAndAuthenticatedCipherText = NSMutableData(data: nonce as Data)
+        nonceAndAuthenticatedCipherText.append(authenticatedCipherText as Data)
         return nonceAndAuthenticatedCipherText
     }
     

--- a/Sodium/ShortHash.swift
+++ b/Sodium/ShortHash.swift
@@ -19,7 +19,7 @@ public class ShortHash {
         guard let output = NSMutableData(length: Bytes) else {
             return nil
         }
-        if crypto_shorthash(output.mutableBytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), key.bytesPtr) != 0 {
+        if crypto_shorthash(output.mutableBytesPtr(), message.bytesPtr(), CUnsignedLongLong(message.length), key.bytesPtr()) != 0 {
             return nil
         }
         return output

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -35,7 +35,7 @@ public class Sign {
         guard let sk = NSMutableData(length: SecretKeyBytes) else {
             return nil
         }
-        if crypto_sign_keypair(pk.mutableBytesPtr, sk.mutableBytesPtr) != 0 {
+        if crypto_sign_keypair(pk.mutableBytesPtr(), sk.mutableBytesPtr()) != 0 {
             return nil
         }
         return KeyPair(publicKey: PublicKey(data: pk as Data), secretKey: SecretKey(data: sk as Data))
@@ -51,7 +51,7 @@ public class Sign {
         guard let sk = NSMutableData(length: SecretKeyBytes) else {
             return nil
         }
-        if crypto_sign_seed_keypair(pk.mutableBytesPtr, sk.mutableBytesPtr, seed.bytesPtr) != 0 {
+        if crypto_sign_seed_keypair(pk.mutableBytesPtr(), sk.mutableBytesPtr(), seed.bytesPtr()) != 0 {
             return nil
         }
         return KeyPair(publicKey: PublicKey(data: pk as Data), secretKey: SecretKey(data: sk as Data))
@@ -64,7 +64,7 @@ public class Sign {
         guard let signedMessage = NSMutableData(length: message.length + Bytes) else {
             return nil
         }
-        if crypto_sign(signedMessage.mutableBytesPtr, nil, message.bytesPtr, CUnsignedLongLong(message.length), secretKey.bytesPtr) != 0 {
+        if crypto_sign(signedMessage.mutableBytesPtr(), nil, message.bytesPtr(), CUnsignedLongLong(message.length), secretKey.bytesPtr()) != 0 {
             return nil
         }
         return signedMessage
@@ -77,7 +77,7 @@ public class Sign {
         guard let signature = NSMutableData(length: Bytes) else {
             return nil
         }
-        if crypto_sign_detached(signature.mutableBytesPtr, nil, message.bytesPtr, CUnsignedLongLong(message.length), secretKey.bytesPtr) != 0 {
+        if crypto_sign_detached(signature.mutableBytesPtr(), nil, message.bytesPtr(), CUnsignedLongLong(message.length), secretKey.bytesPtr()) != 0 {
             return nil
         }
         return signature
@@ -93,7 +93,7 @@ public class Sign {
         if publicKey.length != PublicKeyBytes {
             return false
         }
-        return crypto_sign_verify_detached(signature.bytesPtr, message.bytesPtr, CUnsignedLongLong(message.length), publicKey.bytesPtr) == 0
+        return crypto_sign_verify_detached(signature.bytesPtr(), message.bytesPtr(), CUnsignedLongLong(message.length), publicKey.bytesPtr()) == 0
     }
     
     public func open(signedMessage: NSData, publicKey: PublicKey) -> NSData? {
@@ -104,7 +104,7 @@ public class Sign {
             return nil
         }
         var mlen: CUnsignedLongLong = 0;
-        if crypto_sign_open(message.mutableBytesPtr, &mlen, signedMessage.bytesPtr, CUnsignedLongLong(signedMessage.length), publicKey.bytesPtr) != 0 {
+        if crypto_sign_open(message.mutableBytesPtr(), &mlen, signedMessage.bytesPtr(), CUnsignedLongLong(signedMessage.length), publicKey.bytesPtr()) != 0 {
             return nil
         }
         return message

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -84,8 +84,8 @@ public class Sign {
     }
     
     public func verify(signedMessage: NSData, publicKey: PublicKey) -> Bool {
-        let signature = signedMessage.subdata(with: NSRange(0..<Bytes))
-        let message = signedMessage.subdata(with: NSRange(Bytes..<signedMessage.length))
+        let signature = signedMessage.subdata(with: NSRange(0..<Bytes)) as NSData
+        let message = signedMessage.subdata(with: NSRange(Bytes..<signedMessage.length)) as NSData
         return verify(message: message, publicKey: publicKey, signature: signature)
     }
     

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -86,7 +86,7 @@ public class Sign {
     public func verify(signedMessage: NSData, publicKey: PublicKey) -> Bool {
         let signature = signedMessage.subdata(with: NSRange(0..<Bytes))
         let message = signedMessage.subdata(with: NSRange(Bytes..<signedMessage.length))
-        return verify(message, publicKey: publicKey, signature: signature)
+        return verify(message: message, publicKey: publicKey, signature: signature)
     }
     
     public func verify(message: NSData, publicKey: PublicKey, signature: NSData) -> Bool {

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -13,7 +13,7 @@ public class Sign {
     public let PublicKeyBytes = Int(crypto_sign_publickeybytes())
     public let SecretKeyBytes = Int(crypto_sign_secretkeybytes())
     public let Bytes = Int(crypto_sign_bytes())
-    public let Primitive = String.fromCString(crypto_sign_primitive())
+    public let Primitive = String.init(validatingUTF8:crypto_sign_primitive())
     
     public typealias PublicKey = NSData
     public typealias SecretKey = NSData

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -38,7 +38,7 @@ public class Sign {
         if crypto_sign_keypair(pk.mutableBytesPtr, sk.mutableBytesPtr) != 0 {
             return nil
         }
-        return KeyPair(publicKey: PublicKey(data: pk), secretKey: SecretKey(data: sk))
+        return KeyPair(publicKey: PublicKey(data: pk as Data), secretKey: SecretKey(data: sk as Data))
     }
     
     public func keyPair(seed seed: NSData) -> KeyPair? {
@@ -54,7 +54,7 @@ public class Sign {
         if crypto_sign_seed_keypair(pk.mutableBytesPtr, sk.mutableBytesPtr, seed.bytesPtr) != 0 {
             return nil
         }
-        return KeyPair(publicKey: PublicKey(data: pk), secretKey: SecretKey(data: sk))
+        return KeyPair(publicKey: PublicKey(data: pk as Data), secretKey: SecretKey(data: sk as Data))
     }
     
     public func sign(message: NSData, secretKey: SecretKey) -> NSData? {

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -84,8 +84,8 @@ public class Sign {
     }
     
     public func verify(signedMessage: NSData, publicKey: PublicKey) -> Bool {
-        let signature = signedMessage.subdataWithRange(NSRange(0..<Bytes))
-        let message = signedMessage.subdataWithRange(NSRange(Bytes..<signedMessage.length))
+        let signature = signedMessage.subdata(with: NSRange(0..<Bytes))
+        let message = signedMessage.subdata(with: NSRange(Bytes..<signedMessage.length))
         return verify(message, publicKey: publicKey, signature: signature)
     }
     

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -41,7 +41,7 @@ public class Sign {
         return KeyPair(publicKey: PublicKey(data: pk as Data), secretKey: SecretKey(data: sk as Data))
     }
     
-    public func keyPair(seed seed: NSData) -> KeyPair? {
+    public func keyPair(seed: NSData) -> KeyPair? {
         if seed.length != SeedBytes {
             return nil
         }

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -20,13 +20,11 @@ public class Sodium {
     
     public init?() {
         struct Once {
-            static var once: dispatch_once_t = 0
+            static var once : () = {
+                if sodium_init() == -1 {
+                    abort()
+                }
+            }()
         }
-        dispatch_once(&Once.once) {
-            if sodium_init() == -1 {
-                abort()
-            }
-            ()
-        }
-    }    
+    }
 }

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -42,7 +42,7 @@ public class Utils {
     }
     
     public func hex2bin(hex: String, ignore: String? = nil) -> NSData? {
-        guard let hexData = hex.data(usingEncoding: NSUTF8StringEncoding, allowLossyConversion: false) else {
+        guard let hexData = hex.data(using: NSUTF8StringEncoding, allowLossyConversion: false) else {
             return nil
         }
         let hexDataLen = hexData.count

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -38,7 +38,7 @@ public class Utils {
         if sodium_bin2hex(hexDataBytes, hexData.length, bin.bytesPtr, bin.length) == nil {
             return nil
         }
-        return String.fromCString(hexDataBytes)
+        return String.init(validatingUTF8: hexDataBytes)
     }
     
     public func hex2bin(hex: String, ignore: String? = nil) -> NSData? {

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -52,7 +52,7 @@ public class Utils {
         }
         var binDataLen: size_t = 0
         let ignore_cstr = ignore != nil ? (ignore! as NSString).utf8String : nil
-        if sodium_hex2bin(binData.mutableBytesPtr, binDataCapacity,UnsafePointer<CChar>(hexData.bytes), hexDataLen, ignore_cstr, &binDataLen, nil) != 0 {
+        if sodium_hex2bin(binData.mutableBytesPtr, binDataCapacity,UnsafePointer<CChar>((hexData as NSData).bytes), hexDataLen, ignore_cstr, &binDataLen, nil) != 0 {
             return nil
         }
         binData.length = Int(binDataLen)

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public class Utils {
     public func zero(data: NSMutableData) {
-        sodium_memzero(UnsafeMutablePointer<Void>(data.mutableBytes), data.length)
+        sodium_memzero(UnsafeMutableRawPointer(data.mutableBytes), data.length)
         data.length = 0
     }
     
@@ -18,7 +18,7 @@ public class Utils {
         if b1.length != b2.length {
             return false
         }
-        let res = sodium_memcmp(UnsafePointer<Void>(b1.bytes), UnsafePointer<Void>(b2.bytes), b1.length)
+        let res = sodium_memcmp(UnsafeRawPointer(b1.bytes), UnsafeRawPointer(b2.bytes), b1.length)
         return res == 0;
     }
     
@@ -26,7 +26,7 @@ public class Utils {
         if b1.length != b2.length {
             return nil
         }
-        let res = sodium_compare(b1.bytesPtr, b2.bytesPtr, b1.length)
+        let res = sodium_compare(b1.bytesPtr(), b2.bytesPtr(), b1.length)
         return Int(res);
     }
     
@@ -34,11 +34,10 @@ public class Utils {
         guard let hexData = NSMutableData(length: bin.length * 2 + 1) else {
             return nil
         }
-        let hexDataBytes = UnsafeMutablePointer<CChar>(hexData.mutableBytes)
-        if sodium_bin2hex(hexDataBytes, hexData.length, bin.bytesPtr, bin.length) == nil {
+        if sodium_bin2hex(hexData.mutableBytesPtr(), hexData.length, bin.bytesPtr(), bin.length) == nil {
             return nil
         }
-        return String.init(validatingUTF8: hexDataBytes)
+        return String.init(validatingUTF8: hexData.mutableBytesPtr())
     }
     
     public func hex2bin(hex: String, ignore: String? = nil) -> NSData? {
@@ -52,7 +51,7 @@ public class Utils {
         }
         var binDataLen: size_t = 0
         let ignore_cstr = ignore != nil ? (ignore! as NSString).utf8String : nil
-        if sodium_hex2bin(binData.mutableBytesPtr, binDataCapacity,UnsafePointer<CChar>((hexData as NSData).bytes), hexDataLen, ignore_cstr, &binDataLen, nil) != 0 {
+        if sodium_hex2bin(binData.mutableBytesPtr(), binDataCapacity,(hexData as NSData).bytesPtr(), hexDataLen, ignore_cstr, &binDataLen, nil) != 0 {
             return nil
         }
         binData.length = Int(binDataLen)

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -42,16 +42,16 @@ public class Utils {
     }
     
     public func hex2bin(hex: String, ignore: String? = nil) -> NSData? {
-        guard let hexData = hex.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false) else {
+        guard let hexData = hex.data(usingEncoding: NSUTF8StringEncoding, allowLossyConversion: false) else {
             return nil
         }
-        let hexDataLen = hexData.length
+        let hexDataLen = hexData.count
         let binDataCapacity = hexDataLen / 2
         guard let binData = NSMutableData(length: binDataCapacity) else {
             return nil
         }
         var binDataLen: size_t = 0
-        let ignore_cstr = ignore != nil ? (ignore! as NSString).UTF8String : nil
+        let ignore_cstr = ignore != nil ? (ignore! as NSString).utf8String : nil
         if sodium_hex2bin(binData.mutableBytesPtr, binDataCapacity,UnsafePointer<CChar>(hexData.bytes), hexDataLen, ignore_cstr, &binDataLen, nil) != 0 {
             return nil
         }

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -42,7 +42,7 @@ public class Utils {
     }
     
     public func hex2bin(hex: String, ignore: String? = nil) -> NSData? {
-        guard let hexData = hex.data(using: NSUTF8StringEncoding, allowLossyConversion: false) else {
+        guard let hexData = hex.data(using: String.Encoding.utf8, allowLossyConversion: false) else {
             return nil
         }
         let hexDataLen = hexData.count

--- a/SodiumTests/SodiumTests.swift
+++ b/SodiumTests/SodiumTests.swift
@@ -11,13 +11,13 @@ import Sodium
 
 extension String {
     func toData() -> NSData? {
-        return self.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
+        return self.data(using: String.Encoding.utf8, allowLossyConversion: false)
     }
 }
 
 extension NSData {
     func toString() -> String? {
-        return (NSString(data: self, encoding: NSUTF8StringEncoding) as! String)
+        return (NSString(data: self as Data, encoding: String.Encoding.utf8.rawValue) as! String)
     }
 }
 

--- a/SodiumTests/SodiumTests.swift
+++ b/SodiumTests/SodiumTests.swift
@@ -185,14 +185,14 @@ class SodiumTests: XCTestCase {
         let eq2 = NSData(bytes: [1, 2, 3, 4] as [UInt8], length: 4)
         let eq3 = NSData(bytes: [1, 2, 3, 5] as [UInt8], length: 4)
         let eq4 = NSData(bytes: [1, 2, 3] as [UInt8], length: 3)
-        XCTAssert(sodium.utils.equals(eq1, eq2))
-        XCTAssert(!sodium.utils.equals(eq1, eq3))
-        XCTAssert(!sodium.utils.equals(eq1, eq4))
+        XCTAssert(sodium.utils.equals(b1: eq1, eq2))
+        XCTAssert(!sodium.utils.equals(b1: eq1, eq3))
+        XCTAssert(!sodium.utils.equals(b1: eq1, eq4))
 
-        XCTAssert(sodium.utils.compare(eq1, eq2)! == 0)
-        XCTAssert(sodium.utils.compare(eq1, eq3)! == -1)
-        XCTAssert(sodium.utils.compare(eq3, eq2)! == 1)
-        XCTAssert(sodium.utils.compare(eq1, eq4) == nil)
+        XCTAssert(sodium.utils.compare(b1: eq1, eq2)! == 0)
+        XCTAssert(sodium.utils.compare(b1: eq1, eq3)! == -1)
+        XCTAssert(sodium.utils.compare(b1: eq2, eq3)! == 1)
+        XCTAssert(sodium.utils.compare(b1: eq1, eq4) == nil)
 
         let bin = sodium.utils.hex2bin(hex: "deadbeef")!
         XCTAssert(bin.description == "<deadbeef>")

--- a/SodiumTests/SodiumTests.swift
+++ b/SodiumTests/SodiumTests.swift
@@ -11,7 +11,7 @@ import Sodium
 
 extension String {
     func toData() -> NSData? {
-        return self.data(using: String.Encoding.utf8, allowLossyConversion: false)
+        return self.data(using: String.Encoding.utf8, allowLossyConversion: false) as NSData?
     }
 }
 

--- a/SodiumTests/SodiumTests.swift
+++ b/SodiumTests/SodiumTests.swift
@@ -37,36 +37,36 @@ class SodiumTests: XCTestCase {
         let aliceKeyPair = sodium.box.keyPair()!
         let bobKeyPair = sodium.box.keyPair()!
 
-        let encryptedMessageFromAliceToBob: NSData = sodium.box.seal(message, recipientPublicKey: bobKeyPair.publicKey, senderSecretKey: aliceKeyPair.secretKey)!
-        let decrypted = sodium.box.open(encryptedMessageFromAliceToBob, senderPublicKey: bobKeyPair.publicKey, recipientSecretKey: aliceKeyPair.secretKey)
+        let encryptedMessageFromAliceToBob: NSData = sodium.box.seal(message: message, recipientPublicKey: bobKeyPair.publicKey, senderSecretKey: aliceKeyPair.secretKey)!
+        let decrypted = sodium.box.open(nonceAndAuthenticatedCipherText: encryptedMessageFromAliceToBob, senderPublicKey: bobKeyPair.publicKey, recipientSecretKey: aliceKeyPair.secretKey)
         XCTAssert(decrypted == message)
 
-        let (encryptedMessageFromAliceToBob2, nonce): (NSData, Box.Nonce) = sodium.box.seal(message, recipientPublicKey: bobKeyPair.publicKey, senderSecretKey: aliceKeyPair.secretKey)!
-        let decrypted2 = sodium.box.open(encryptedMessageFromAliceToBob2, senderPublicKey: aliceKeyPair.publicKey, recipientSecretKey: bobKeyPair.secretKey, nonce: nonce)
+        let (encryptedMessageFromAliceToBob2, nonce): (NSData, Box.Nonce) = sodium.box.seal(message: message, recipientPublicKey: bobKeyPair.publicKey, senderSecretKey: aliceKeyPair.secretKey)!
+        let decrypted2 = sodium.box.open(authenticatedCipherText: encryptedMessageFromAliceToBob2, senderPublicKey: aliceKeyPair.publicKey, recipientSecretKey: bobKeyPair.secretKey, nonce: nonce)
         XCTAssert(decrypted2 == message)
 
-        let (encryptedMessageFromAliceToBob3, nonce2, mac): (NSData, Box.Nonce, Box.MAC) = sodium.box.seal(message, recipientPublicKey: bobKeyPair.publicKey, senderSecretKey: aliceKeyPair.secretKey)!
-        let decrypted3 = sodium.box.open(encryptedMessageFromAliceToBob3, senderPublicKey: aliceKeyPair.publicKey, recipientSecretKey: bobKeyPair.secretKey, nonce: nonce2, mac: mac)
+        let (encryptedMessageFromAliceToBob3, nonce2, mac): (NSData, Box.Nonce, Box.MAC) = sodium.box.seal(message: message, recipientPublicKey: bobKeyPair.publicKey, senderSecretKey: aliceKeyPair.secretKey)!
+        let decrypted3 = sodium.box.open(authenticatedCipherText: encryptedMessageFromAliceToBob3, senderPublicKey: aliceKeyPair.publicKey, recipientSecretKey: bobKeyPair.secretKey, nonce: nonce2, mac: mac)
         XCTAssert(decrypted3 == message)
 
-        let encryptedMessageToBob: NSData = sodium.box.seal(message, recipientPublicKey: bobKeyPair.publicKey)!
-        let decrypted4 = sodium.box.open(encryptedMessageToBob, recipientPublicKey: bobKeyPair.publicKey,
+        let encryptedMessageToBob: NSData = sodium.box.seal(message: message, recipientPublicKey: bobKeyPair.publicKey)!
+        let decrypted4 = sodium.box.open(anonymousCipherText: encryptedMessageToBob, recipientPublicKey: bobKeyPair.publicKey,
             recipientSecretKey: bobKeyPair.secretKey)
         XCTAssert(decrypted4 == message)
 
         // beforenm tests
         // The two beforenm keys calculated by Alice and Bob separately should be identical
-        let aliceBeforenm = sodium.box.beforenm(bobKeyPair.publicKey, senderSecretKey: aliceKeyPair.secretKey)!
-        let bobBeforenm = sodium.box.beforenm(aliceKeyPair.publicKey, senderSecretKey: bobKeyPair.secretKey)!
+        let aliceBeforenm = sodium.box.beforenm(recipientPublicKey: bobKeyPair.publicKey, senderSecretKey: aliceKeyPair.secretKey)!
+        let bobBeforenm = sodium.box.beforenm(recipientPublicKey: aliceKeyPair.publicKey, senderSecretKey: bobKeyPair.secretKey)!
         XCTAssert(aliceBeforenm == bobBeforenm)
 
         // Make sure the encryption using beforenm works
-        let encryptedMessageBeforenm: NSData = sodium.box.seal(message, beforenm: aliceBeforenm)!
-        let decryptedBeforenm = sodium.box.open(encryptedMessageBeforenm, beforenm: aliceBeforenm)
+        let encryptedMessageBeforenm: NSData = sodium.box.seal(message: message, beforenm: aliceBeforenm)!
+        let decryptedBeforenm = sodium.box.open(nonceAndAuthenticatedCipherText: encryptedMessageBeforenm, beforenm: aliceBeforenm)
         XCTAssert(decryptedBeforenm == message)
 
-        let (encryptedMessageBeforenm2, nonceBeforenm): (NSData, Box.Nonce) = sodium.box.seal(message, beforenm: aliceBeforenm)!
-        let decryptedBeforenm2 = sodium.box.open(encryptedMessageBeforenm2, beforenm: aliceBeforenm, nonce: nonceBeforenm)
+        let (encryptedMessageBeforenm2, nonceBeforenm): (NSData, Box.Nonce) = sodium.box.seal(message: message, beforenm: aliceBeforenm)!
+        let decryptedBeforenm2 = sodium.box.open(authenticatedCipherText: encryptedMessageBeforenm2, beforenm: aliceBeforenm, nonce: nonceBeforenm)
         XCTAssert(decryptedBeforenm2 == message)
     }
 
@@ -75,61 +75,61 @@ class SodiumTests: XCTestCase {
         let secretKey = sodium.secretBox.key()!
 
         // test simple nonce + mac + message box
-        let encrypted: NSData = sodium.secretBox.seal(message, secretKey: secretKey)!
-        let decrypted = sodium.secretBox.open(encrypted, secretKey: secretKey)!
+        let encrypted: NSData = sodium.secretBox.seal(message: message, secretKey: secretKey)!
+        let decrypted = sodium.secretBox.open(nonceAndAuthenticatedCipherText: encrypted, secretKey: secretKey)!
         XCTAssert(decrypted == message)
 
-        XCTAssertNil(sodium.secretBox.open(encrypted, secretKey: sodium.secretBox.key()!), "Shouldn't be able to decrypt with a bad key")
+        XCTAssertNil(sodium.secretBox.open(nonceAndAuthenticatedCipherText: encrypted, secretKey: sodium.secretBox.key()!), "Shouldn't be able to decrypt with a bad key")
 
         // test (mac + message, nonce) box
-        let (encrypted2, nonce2) = sodium.secretBox.seal(message, secretKey: secretKey)!
-        let decrypted2 = sodium.secretBox.open(encrypted2, secretKey: secretKey, nonce: nonce2)
+        let (encrypted2, nonce2) = sodium.secretBox.seal(message: message, secretKey: secretKey)!
+        let decrypted2 = sodium.secretBox.open(authenticatedCipherText: encrypted2, secretKey: secretKey, nonce: nonce2)
         XCTAssert(decrypted2 == message)
 
-        XCTAssertNil(sodium.secretBox.open(encrypted2, secretKey: secretKey, nonce: sodium.secretBox.nonce()!), "Shouldn't be able to decrypt with an invalid nonce")
+        XCTAssertNil(sodium.secretBox.open(authenticatedCipherText: encrypted2, secretKey: secretKey, nonce: sodium.secretBox.nonce()!), "Shouldn't be able to decrypt with an invalid nonce")
 
         // test (message, nonce, mac) box
-        let (encrypted3, nonce3, mac3) = sodium.secretBox.seal(message, secretKey: secretKey)!
-        let decrypted3 = sodium.secretBox.open(encrypted3, secretKey: secretKey, nonce: nonce3, mac: mac3)
+        let (encrypted3, nonce3, mac3) = sodium.secretBox.seal(message: message, secretKey: secretKey)!
+        let decrypted3 = sodium.secretBox.open(cipherText: encrypted3, secretKey: secretKey, nonce: nonce3, mac: mac3)
         XCTAssert(decrypted3 == message)
 
-        let (encrypted4, nonce4, mac4) = sodium.secretBox.seal(message, secretKey: secretKey)!
-        XCTAssertNil(sodium.secretBox.open(encrypted4, secretKey: secretKey, nonce: nonce3, mac: mac4), "Shouldn't be able to decrypt with an invalid MAC")
-        XCTAssertNil(sodium.secretBox.open(encrypted4, secretKey: secretKey, nonce: nonce4, mac: mac3), "Shouldn't be able to decrypt with an invalid nonce")
+        let (encrypted4, nonce4, mac4) = sodium.secretBox.seal(message: message, secretKey: secretKey)!
+        XCTAssertNil(sodium.secretBox.open(cipherText: encrypted4, secretKey: secretKey, nonce: nonce3, mac: mac4), "Shouldn't be able to decrypt with an invalid MAC")
+        XCTAssertNil(sodium.secretBox.open(cipherText: encrypted4, secretKey: secretKey, nonce: nonce4, mac: mac3), "Shouldn't be able to decrypt with an invalid nonce")
     }
 
     func testGenericHash() {
         let message = "My Test Message".toData()!
-        let h1 = sodium.utils.bin2hex(sodium.genericHash.hash(message)!)!
+        let h1 = sodium.utils.bin2hex(bin: sodium.genericHash.hash(message: message)!)!
         XCTAssert(h1 == "64a9026fca646c31df54426ad15a341e2444d8a1863d57eb27abecf239609f75")
 
-        let key = sodium.utils.hex2bin("64 a9 02 6f ca 64 6c 31 df 54", ignore: " ")
-        let h2 = sodium.utils.bin2hex(sodium.genericHash.hash(message, key: key)!)!
+        let key = sodium.utils.hex2bin(hex: "64 a9 02 6f ca 64 6c 31 df 54", ignore: " ")
+        let h2 = sodium.utils.bin2hex(bin: sodium.genericHash.hash(message: message, key: key)!)!
         XCTAssert(h2 == "1773f324cba2e7b0017e32d7e44f7afd1036c5d4ef9a80ae0e52e95a629844cd")
 
-        let h3 = sodium.utils.bin2hex(sodium.genericHash.hash(message, key: key, outputLength: sodium.genericHash.BytesMax)!)!
+        let h3 = sodium.utils.bin2hex(bin: sodium.genericHash.hash(message: message, key: key, outputLength: sodium.genericHash.BytesMax)!)!
         XCTAssert(h3 == "cba85e39f2d03923b2f66aba99b204333edc34a8443ab1700f7920c7abcc6639963a953f35162a520b21072ab906457d21f1645e6e3985858ee95a84d0771f07")
 
         let s1 = sodium.genericHash.initStream()!
-        s1.update(message)
-        let h4 = sodium.utils.bin2hex(s1.final()!)!
+        s1.update(input: message)
+        let h4 = sodium.utils.bin2hex(bin: s1.final()!)!
         XCTAssert(h4 == h1)
 
-        let s2 = sodium.genericHash.initStream(key, outputLength: sodium.genericHash.Bytes)!
-        s2.update(message)
-        let h5 = sodium.utils.bin2hex(s2.final()!)!
+        let s2 = sodium.genericHash.initStream(key: key, outputLength: sodium.genericHash.Bytes)!
+        s2.update(input: message)
+        let h5 = sodium.utils.bin2hex(bin: s2.final()!)!
         XCTAssert(h5 == h2)
 
-        let s3 = sodium.genericHash.initStream(key, outputLength: sodium.genericHash.BytesMax)!
-        s3.update(message)
-        let h6 = sodium.utils.bin2hex(s3.final()!)!
+        let s3 = sodium.genericHash.initStream(key: key, outputLength: sodium.genericHash.BytesMax)!
+        s3.update(input: message)
+        let h6 = sodium.utils.bin2hex(bin: s3.final()!)!
         XCTAssert(h6 == h3)
     }
 
     func testRandomBytes() {
-        let randomLen = 100 + Int(sodium.randomBytes.uniform(100))
-        let random1 = sodium.randomBytes.buf(randomLen)!
-        let random2 = sodium.randomBytes.buf(randomLen)!
+        let randomLen = 100 + Int(sodium.randomBytes.uniform(upperBound: 100))
+        let random1 = sodium.randomBytes.buf(length: randomLen)!
+        let random2 = sodium.randomBytes.buf(length: randomLen)!
         XCTAssert(random1.length == randomLen)
         XCTAssert(random2.length == randomLen)
         XCTAssert(random1 != random2)
@@ -144,9 +144,9 @@ class SodiumTests: XCTestCase {
         XCTAssert(c1 < 10)
 
         var c2 = 0
-        let ref2 = self.sodium.randomBytes.uniform(100_000)
+        let ref2 = self.sodium.randomBytes.uniform(upperBound: 100_000)
         for _ in (0..<100) {
-            if sodium.randomBytes.uniform(100_000) == ref2 {
+            if sodium.randomBytes.uniform(upperBound: 100_000) == ref2 {
                 c2 += 1
             }
         }
@@ -155,30 +155,30 @@ class SodiumTests: XCTestCase {
 
     func testShortHash() {
         let message = "My Test Message".toData()!
-        let key = sodium.utils.hex2bin("00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff", ignore: " ")!
-        let h = sodium.utils.bin2hex(sodium.shortHash.hash(message, key: key)!)!
+        let key = sodium.utils.hex2bin(hex: "00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff", ignore: " ")!
+        let h = sodium.utils.bin2hex(bin: sodium.shortHash.hash(message: message, key: key)!)!
         XCTAssert(h == "bb9be85c918015ea")
     }
 
     func testSignature() {
         let message = "My Test Message".toData()!
-        let keyPair = sodium.sign.keyPair(seed: sodium.utils.hex2bin("00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff 00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff", ignore: " ")!)!
-        let signedMessage = sodium.sign.sign(message, secretKey: keyPair.secretKey)!
-        XCTAssert(sodium.utils.bin2hex(signedMessage)! == "ce8437d58a27c4d91426d35b24cfaf1e49f95b213c15eddb198f4a8d24c0fdd0df3e7f7a894f60ec15cff25b5f6f27399ce01db0e2649fc54c91cafb8dd48a094d792054657374204d657373616765")
+        let keyPair = sodium.sign.keyPair(seed: sodium.utils.hex2bin(hex: "00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff 00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff", ignore: " ")!)!
+        let signedMessage = sodium.sign.sign(message: message, secretKey: keyPair.secretKey)!
+        XCTAssert(sodium.utils.bin2hex(bin: signedMessage)! == "ce8437d58a27c4d91426d35b24cfaf1e49f95b213c15eddb198f4a8d24c0fdd0df3e7f7a894f60ec15cff25b5f6f27399ce01db0e2649fc54c91cafb8dd48a094d792054657374204d657373616765")
 
-        let signature = sodium.sign.signature(message, secretKey: keyPair.secretKey)!
-        XCTAssert(sodium.utils.bin2hex(signature)! == "ce8437d58a27c4d91426d35b24cfaf1e49f95b213c15eddb198f4a8d24c0fdd0df3e7f7a894f60ec15cff25b5f6f27399ce01db0e2649fc54c91cafb8dd48a09")
+        let signature = sodium.sign.signature(message: message, secretKey: keyPair.secretKey)!
+        XCTAssert(sodium.utils.bin2hex(bin: signature)! == "ce8437d58a27c4d91426d35b24cfaf1e49f95b213c15eddb198f4a8d24c0fdd0df3e7f7a894f60ec15cff25b5f6f27399ce01db0e2649fc54c91cafb8dd48a09")
 
-        XCTAssert(sodium.sign.verify(signedMessage, publicKey: keyPair.publicKey) == true)
-        XCTAssert(sodium.sign.verify(message, publicKey: keyPair.publicKey, signature: signature) == true)
+        XCTAssert(sodium.sign.verify(signedMessage: signedMessage, publicKey: keyPair.publicKey) == true)
+        XCTAssert(sodium.sign.verify(message: message, publicKey: keyPair.publicKey, signature: signature) == true)
 
-        let unsignedMessage = sodium.sign.open(signedMessage, publicKey: keyPair.publicKey)!
+        let unsignedMessage = sodium.sign.open(signedMessage: signedMessage, publicKey: keyPair.publicKey)!
         XCTAssert(unsignedMessage == message)
     }
 
     func testUtils() {
         let dataToZero = NSMutableData(bytes: [1, 2, 3, 4] as [UInt8], length: 4)
-        sodium.utils.zero(dataToZero)
+        sodium.utils.zero(data: dataToZero)
         XCTAssert(dataToZero.length == 0)
 
         let eq1 = NSData(bytes: [1, 2, 3, 4] as [UInt8], length: 4)
@@ -194,46 +194,46 @@ class SodiumTests: XCTestCase {
         XCTAssert(sodium.utils.compare(eq3, eq2)! == 1)
         XCTAssert(sodium.utils.compare(eq1, eq4) == nil)
 
-        let bin = sodium.utils.hex2bin("deadbeef")!
+        let bin = sodium.utils.hex2bin(hex: "deadbeef")!
         XCTAssert(bin.description == "<deadbeef>")
-        let hex = sodium.utils.bin2hex(bin)
+        let hex = sodium.utils.bin2hex(bin: bin)
         XCTAssert(hex == "deadbeef")
-        let bin2 = sodium.utils.hex2bin("de-ad be:ef", ignore: ":- ")!
+        let bin2 = sodium.utils.hex2bin(hex: "de-ad be:ef", ignore: ":- ")!
         XCTAssert(bin2 == bin)
     }
 
     func testScrypt() {
-        let passwordLen = Int(sodium.randomBytes.uniform(64))
-        let password = sodium.randomBytes.buf(passwordLen)!
-        let hash = sodium.pwHash.scrypt.str(password, opsLimit: sodium.pwHash.scrypt.OpsLimitInteractive, memLimit: sodium.pwHash.scrypt.MemLimitInteractive)
-        XCTAssert(hash?.lengthOfBytesUsingEncoding(NSUTF8StringEncoding) == sodium.pwHash.scrypt.StrBytes)
-        let verify = sodium.pwHash.scrypt.strVerify(hash!, passwd: password)
+        let passwordLen = Int(sodium.randomBytes.uniform(upperBound: 64))
+        let password = sodium.randomBytes.buf(length: passwordLen)!
+        let hash = sodium.pwHash.scrypt.str(passwd: password, opsLimit: sodium.pwHash.scrypt.OpsLimitInteractive, memLimit: sodium.pwHash.scrypt.MemLimitInteractive)
+        XCTAssert(hash?.lengthOfBytesUsingEncoding(String.Encoding.utf8) == sodium.pwHash.scrypt.StrBytes)
+        let verify = sodium.pwHash.scrypt.strVerify(hash: hash!, passwd: password)
         XCTAssert(verify == true)
-        let password2 = sodium.randomBytes.buf(passwordLen)!
-        let verify2 = sodium.pwHash.scrypt.strVerify(hash!, passwd: password2)
+        let password2 = sodium.randomBytes.buf(length: passwordLen)!
+        let verify2 = sodium.pwHash.scrypt.strVerify(hash: hash!, passwd: password2)
         XCTAssert(verify2 == false)
 
         let password3 = "My Test Message".toData()!
         let salt = NSData(bytes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32] as [UInt8], length: 32)
-        let hash2 = sodium.pwHash.scrypt.hash(64, passwd: password3, salt: salt, opsLimit: sodium.pwHash.scrypt.OpsLimitInteractive, memLimit: sodium.pwHash.scrypt.MemLimitInteractive)
-        NSLog(sodium.utils.bin2hex(hash2!)!)
-        XCTAssert(sodium.utils.bin2hex(hash2!)! == "6f00c5630b0a113be73721d2bab7800c0fce4b4e7a74451704b53afcded3d9e85fbe1acea7d2aa0fecb3027e35d745547b1041d6c51f731bd0aa934da89f7adf")
+        let hash2 = sodium.pwHash.scrypt.hash(outputLength: 64, passwd: password3, salt: salt, opsLimit: sodium.pwHash.scrypt.OpsLimitInteractive, memLimit: sodium.pwHash.scrypt.MemLimitInteractive)
+        NSLog(sodium.utils.bin2hex(bin: hash2!)!)
+        XCTAssert(sodium.utils.bin2hex(bin: hash2!)! == "6f00c5630b0a113be73721d2bab7800c0fce4b4e7a74451704b53afcded3d9e85fbe1acea7d2aa0fecb3027e35d745547b1041d6c51f731bd0aa934da89f7adf")
     }
 
     func testPwHash() {
-        let passwordLen = Int(sodium.randomBytes.uniform(64))
-        let password = sodium.randomBytes.buf(passwordLen)!
-        let hash = sodium.pwHash.str(password, opsLimit: sodium.pwHash.OpsLimitInteractive, memLimit: sodium.pwHash.MemLimitInteractive)
-        XCTAssert(hash?.lengthOfBytesUsingEncoding(NSUTF8StringEncoding) == sodium.pwHash.StrBytes)
-        let verify = sodium.pwHash.strVerify(hash!, passwd: password)
+        let passwordLen = Int(sodium.randomBytes.uniform(upperBound: 64))
+        let password = sodium.randomBytes.buf(length: passwordLen)!
+        let hash = sodium.pwHash.str(passwd: password, opsLimit: sodium.pwHash.OpsLimitInteractive, memLimit: sodium.pwHash.MemLimitInteractive)
+        XCTAssert(hash?.lengthOfBytesUsingEncoding(String.Encoding.utf8) == sodium.pwHash.StrBytes)
+        let verify = sodium.pwHash.strVerify(hash: hash!, passwd: password)
         XCTAssert(verify == true)
-        let password2 = sodium.randomBytes.buf(passwordLen)!
-        let verify2 = sodium.pwHash.strVerify(hash!, passwd: password2)
+        let password2 = sodium.randomBytes.buf(length: passwordLen)!
+        let verify2 = sodium.pwHash.strVerify(hash: hash!, passwd: password2)
         XCTAssert(verify2 == false)
 
         let password3 = "My Test Message".toData()!
         let salt = NSData(bytes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as [UInt8], length: 16)
-        let hash2 = sodium.pwHash.hash(64, passwd: password3, salt: salt, opsLimit: sodium.pwHash.OpsLimitInteractive, memLimit: sodium.pwHash.MemLimitInteractive)
-        XCTAssert(sodium.utils.bin2hex(hash2!)! == "51d659ee6f8790042688274c5bc8a6296390cdc786d2341c3553b01a5c3f7ff1190e04b86a878538b17ef10e74baa19295479f3e3ee587ce571f366fc66e2fdc")
+        let hash2 = sodium.pwHash.hash(outputLength: 64, passwd: password3, salt: salt, opsLimit: sodium.pwHash.OpsLimitInteractive, memLimit: sodium.pwHash.MemLimitInteractive)
+        XCTAssert(sodium.utils.bin2hex(bin: hash2!)! == "51d659ee6f8790042688274c5bc8a6296390cdc786d2341c3553b01a5c3f7ff1190e04b86a878538b17ef10e74baa19295479f3e3ee587ce571f366fc66e2fdc")
     }
 }

--- a/SodiumTests/SodiumTests.swift
+++ b/SodiumTests/SodiumTests.swift
@@ -191,7 +191,7 @@ class SodiumTests: XCTestCase {
 
         XCTAssert(sodium.utils.compare(b1: eq1, eq2)! == 0)
         XCTAssert(sodium.utils.compare(b1: eq1, eq3)! == -1)
-        XCTAssert(sodium.utils.compare(b1: eq2, eq3)! == 1)
+        XCTAssert(sodium.utils.compare(b1: eq3, eq2)! == 1)
         XCTAssert(sodium.utils.compare(b1: eq1, eq4) == nil)
 
         let bin = sodium.utils.hex2bin(hex: "deadbeef")!

--- a/SodiumTests/SodiumTests.swift
+++ b/SodiumTests/SodiumTests.swift
@@ -206,7 +206,7 @@ class SodiumTests: XCTestCase {
         let passwordLen = Int(sodium.randomBytes.uniform(upperBound: 64))
         let password = sodium.randomBytes.buf(length: passwordLen)!
         let hash = sodium.pwHash.scrypt.str(passwd: password, opsLimit: sodium.pwHash.scrypt.OpsLimitInteractive, memLimit: sodium.pwHash.scrypt.MemLimitInteractive)
-        XCTAssert(hash?.lengthOfBytesUsingEncoding(String.Encoding.utf8) == sodium.pwHash.scrypt.StrBytes)
+        XCTAssert(hash?.lengthOfBytes(using: String.Encoding.utf8) == sodium.pwHash.scrypt.StrBytes)
         let verify = sodium.pwHash.scrypt.strVerify(hash: hash!, passwd: password)
         XCTAssert(verify == true)
         let password2 = sodium.randomBytes.buf(length: passwordLen)!
@@ -224,7 +224,7 @@ class SodiumTests: XCTestCase {
         let passwordLen = Int(sodium.randomBytes.uniform(upperBound: 64))
         let password = sodium.randomBytes.buf(length: passwordLen)!
         let hash = sodium.pwHash.str(passwd: password, opsLimit: sodium.pwHash.OpsLimitInteractive, memLimit: sodium.pwHash.MemLimitInteractive)
-        XCTAssert(hash?.lengthOfBytesUsingEncoding(String.Encoding.utf8) == sodium.pwHash.StrBytes)
+        XCTAssert(hash?.lengthOfBytes(using: String.Encoding.utf8) == sodium.pwHash.StrBytes)
         let verify = sodium.pwHash.strVerify(hash: hash!, passwd: password)
         XCTAssert(verify == true)
         let password2 = sodium.randomBytes.buf(length: passwordLen)!


### PR DESCRIPTION
Hi there!

In order to successfully compile swift-sodium using Xcode 8 (8S193k) a few changes were necessary:

1. Fix some renamed method names
2. Fix argument labels. Now, the first parameter of an method must have an argument label.
E.g. seal(message, secretKey: secretKey) must be written as seal(message: 
message, secretKey: secretKey)
3. The data argument of the NSMutableData initialiser uses the new "Data" type => Fix cast errors
4. Replace dispatch_once_t with a static var (which uses dispatch_once_t in the background)

All test are still passing.
Maybe it's worth considering to open a second branch besides the Master, which contains a Swift 3 compatible version of swift-sodium?