### PR TITLE
Fix warnings for unused results

### DIFF
--- a/SodiumTests/SodiumTests.swift
+++ b/SodiumTests/SodiumTests.swift
@@ -111,17 +111,17 @@ class SodiumTests: XCTestCase {
         XCTAssert(h3 == "cba85e39f2d03923b2f66aba99b204333edc34a8443ab1700f7920c7abcc6639963a953f35162a520b21072ab906457d21f1645e6e3985858ee95a84d0771f07")
 
         let s1 = sodium.genericHash.initStream()!
-        s1.update(input: message)
+        XCTAssertTrue(s1.update(input: message))
         let h4 = sodium.utils.bin2hex(bin: s1.final()!)!
         XCTAssert(h4 == h1)
 
         let s2 = sodium.genericHash.initStream(key: key, outputLength: sodium.genericHash.Bytes)!
-        s2.update(input: message)
+        XCTAssertTrue(s2.update(input: message))
         let h5 = sodium.utils.bin2hex(bin: s2.final()!)!
         XCTAssert(h5 == h2)
 
         let s3 = sodium.genericHash.initStream(key: key, outputLength: sodium.genericHash.BytesMax)!
-        s3.update(input: message)
+        XCTAssertTrue(s3.update(input: message))
         let h6 = sodium.utils.bin2hex(bin: s3.final()!)!
         XCTAssert(h6 == h3)
     }


### PR DESCRIPTION
This removes three warnings from the build, and it's probably not bad to check the result there to see if the operation succeeded.

The warnings were:

> Result of call to update(input:) is unused.