### PR TITLE
Update README.md examples so that they will compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ Authenticated Encryption
 let sodium = Sodium()!
 let aliceKeyPair = sodium.box.keyPair()!
 let bobKeyPair = sodium.box.keyPair()!
-let message = "My Test Message".dataUsingEncoding(NSUTF8StringEncoding)!
+let message = "My Test Message".data(using:.utf8)!
 
 let encryptedMessageFromAliceToBob: NSData =
-  sodium.box.seal(message,
-                  recipientPublicKey: bobKeyPair.publicKey,
-                  senderSecretKey: aliceKeyPair.secretKey)!
+    sodium.box.seal(message: message as NSData,
+                    recipientPublicKey: bobKeyPair.publicKey,
+                    senderSecretKey: aliceKeyPair.secretKey)!
 
 let messageVerifiedAndDecryptedByBob =
-  sodium.box.open(encryptedMessageFromAliceToBob,
-                  senderPublicKey: alicebKeyPair.publicKey,
-                  recipientSecretKey: bobKeyPair.secretKey)
+    sodium.box.open(nonceAndAuthenticatedCipherText: encryptedMessageFromAliceToBob,
+                    senderPublicKey: aliceKeyPair.publicKey,
+                    recipientSecretKey: bobKeyPair.secretKey)
 ```
 
 `seal()` automatically generates a nonce and prepends it to the
@@ -71,15 +71,15 @@ Anonymous Encryption (Sealed Boxes)
 ```swift
 let sodium = Sodium()!
 let bobKeyPair = sodium.box.keyPair()!
-let message = "My Test Message".dataUsingEncoding(NSUTF8StringEncoding)!
+let message = "My Test Message".data(using:.utf8)!
 
 let encryptedMessageToBob =
-  sodium.box.seal(message, recipientPublicKey: bobKeyPair.publicKey)!
+    sodium.box.seal(message: message as NSData, recipientPublicKey: bobKeyPair.publicKey)!
 
 let messageDecryptedByBob =
-  sodium.box.open(encryptedMessageToBob,
-                  recipientPublicKey: bobKeyPair.publicKey,
-                  recipientSecretKey: bobKeyPair.secretKey)
+    sodium.box.open(anonymousCipherText: encryptedMessageToBob,
+                    recipientPublicKey: bobKeyPair.publicKey,
+                    recipientSecretKey: bobKeyPair.secretKey)
 ```
 
 `seal()` generates an ephemeral keypair, uses the ephemeral secret
@@ -97,13 +97,13 @@ Detached signatures
 
 ```swift
 let sodium = Sodium()!
-let message = "My Test Message".dataUsingEncoding(NSUTF8StringEncoding)!
+let message = "My Test Message".data(using:.utf8)!
 let keyPair = sodium.sign.keyPair()!
-let signature = sodium.sign.signature(message, secretKey: keyPair.secretKey)!
-if sodium.sign.verify(message,
+let signature = sodium.sign.signature(message: message as NSData, secretKey: keyPair.secretKey)!
+if sodium.sign.verify(message: message as NSData,
                       publicKey: keyPair.publicKey,
                       signature: signature) {
-  // signature is valid
+    // signature is valid
 }
 ```
 
@@ -112,11 +112,11 @@ Attached signatures
 
 ```swift
 let sodium = Sodium()!
-let message = "My Test Message".dataUsingEncoding(NSUTF8StringEncoding)!
+let message = "My Test Message".data(using:.utf8)!
 let keyPair = sodium.sign.keyPair()!
-let signedMessage = sodium.sign.sign(message, secretKey: keyPair.secretKey)!
-if let unsignedMessage = sodium.sign.open(signedMessage, publicKey: keyPair.publicKey) {
-  // signature is valid
+let signedMessage = sodium.sign.sign(message: message as NSData, secretKey: keyPair.secretKey)!
+if let unsignedMessage = sodium.sign.open(signedMessage: signedMessage, publicKey: keyPair.publicKey) {
+    // signature is valid
 }
 ```
 
@@ -125,11 +125,11 @@ Secret-key authenticated encryption
 
 ```swift
 let sodium = Sodium()!
-let message = "My Test Message".dataUsingEncoding(NSUTF8StringEncoding)!
+let message = "My Test Message".data(using:.utf8)!
 let secretKey = sodium.secretBox.key()!
-let encrypted: NSData = sodium.secretBox.seal(message, secretKey: secretKey)!
-if let decrypted = sodium.secretBox.open(encrypted, secretKey: secretKey) {
-  // authenticator is valid, decrypted contains the original message
+let encrypted: NSData = sodium.secretBox.seal(message: message as NSData, secretKey: secretKey)!
+if let decrypted = sodium.secretBox.open(nonceAndAuthenticatedCipherText: encrypted, secretKey: secretKey) {
+    // authenticator is valid, decrypted contains the original message
 }
 ```
 
@@ -141,8 +141,8 @@ Deterministic hashing
 
 ```swift
 let sodium = Sodium()!
-let message = "My Test Message".dataUsingEncoding(NSUTF8StringEncoding)!
-let h = sodium.genericHash.hash(message)
+let message = "My Test Message".data(using:.utf8)!
+let h = sodium.genericHash.hash(message: message as NSData)
 ```
 
 Keyed hashing
@@ -150,9 +150,9 @@ Keyed hashing
 
 ```swift
 let sodium = Sodium()!
-let message = "My Test Message".dataUsingEncoding(NSUTF8StringEncoding)!
-let key = "Secret key".dataUsingEncoding(NSUTF8StringEncoding)!
-let h = sodium.genericHash.hash(message, key: key)
+let message = "My Test Message".data(using:.utf8)!
+let key = "Secret key".data(using:.utf8)!
+let h = sodium.genericHash.hash(message: message as NSData, key: key as NSData)
 ```
 
 Streaming
@@ -160,12 +160,12 @@ Streaming
 
 ```swift
 let sodium = Sodium()!
-let message1 = "My Test ".dataUsingEncoding(NSUTF8StringEncoding)!
-let message2 = "Message".dataUsingEncoding(NSUTF8StringEncoding)!
-let key = "Secret key".dataUsingEncoding(NSUTF8StringEncoding)!
-let stream = sodium.genericHash.initStream(key)!
-stream.update(message1)
-stream.update(message2)
+let message1 = "My Test ".data(using:.utf8)!
+let message2 = "Message".data(using:.utf8)!
+let key = "Secret key".data(using:.utf8)!
+let stream = sodium.genericHash.initStream(key: key as NSData)!
+stream.update(input: message1 as NSData)
+stream.update(input: message2 as NSData)
 let h = stream.final()
 ```
 
@@ -174,9 +174,9 @@ Short-output hashing (SipHash)
 
 ```swift
 let sodium = Sodium()!
-let message = "My Test Message".dataUsingEncoding(NSUTF8StringEncoding)!
-let key = sodium.randomBytes.buf(sodium.shortHash.KeyBytes)!
-let h = sodium.shortHash.hash(message, key: key)
+let message = "My Test Message".data(using:.utf8)!
+let key = sodium.randomBytes.buf(length: sodium.shortHash.KeyBytes)!
+let h = sodium.shortHash.hash(message: message as NSData, key: key as NSData)
 ```
 
 Random numbers generation
@@ -184,7 +184,7 @@ Random numbers generation
 
 ```swift
 let sodium = Sodium()!
-let randomData = sodium.randomBytes.buf(1000)
+let randomData = sodium.randomBytes.buf(length: 1000)
 ```
 
 Password hashing
@@ -194,15 +194,15 @@ Using Argon2i:
 
 ```swift
 let sodium = Sodium()!
-let password = "Correct Horse Battery Staple".dataUsingEncoding(NSUTF8StringEncoding)!
-let hashedStr = sodium.pwHash.str(password,
-  opsLimit: sodium.pwHash.OpsLimitInteractive,
-  memLimit: sodium.pwHash.MemLimitInteractive)!
+let password = "Correct Horse Battery Staple".data(using:.utf8)!
+let hashedStr = sodium.pwHash.str(passwd: password as NSData,
+                                  opsLimit: sodium.pwHash.OpsLimitInteractive,
+                                  memLimit: sodium.pwHash.MemLimitInteractive)!
 
-if sodium.pwHash.strVerify(hashedStr, passwd: password) {
-  // Password matches the given hash string
+if sodium.pwHash.strVerify(hash: hashedStr, passwd: password as NSData) {
+    // Password matches the given hash string
 } else {
-  // Password doesn't match the given hash string
+    // Password doesn't match the given hash string
 }
 ```
 
@@ -214,8 +214,8 @@ Zeroing memory
 
 ```swift
 let sodium = Sodium()!
-var dataToZero: NSMutableData
-sodium.utils.zero(dataToZero)
+var dataToZero: NSMutableData = NSMutableData(data:"Message".data(using:.utf8)!)
+sodium.utils.zero(data: dataToZero)
 ```
 
 Constant-time comparison
@@ -223,9 +223,9 @@ Constant-time comparison
 
 ```swift
 let sodium = Sodium()!
-let secret1: NSData
-let secret2: NSData
-let equality = sodium.utils.equals(secret1, secret2)
+let secret1: NSData = NSData(data:"Secret key".data(using:.utf8)!)
+let secret2: NSData = NSData(data:"Secret key".data(using:.utf8)!)
+let equality = sodium.utils.equals(b1: secret1, secret2)
 ```
 
 Constant-time hexadecimal encoding
@@ -233,8 +233,8 @@ Constant-time hexadecimal encoding
 
 ```swift
 let sodium = Sodium()!
-let data: NSData
-let hex = sodium.utils.bin2hex(data)
+let data: NSData = NSData(data:"Secret key".data(using:.utf8)!)
+let hex = sodium.utils.bin2hex(bin: data)
 ```
 
 Hexadecimal decoding
@@ -242,6 +242,6 @@ Hexadecimal decoding
 
 ```swift
 let sodium = Sodium()!
-let data1 = sodium.utils.hex2bin("deadbeef")
-let data2 = sodium.utils.hex2bin("de:ad be:ef", ignore: " :")
+let data1 = sodium.utils.hex2bin(hex: "deadbeef")
+let data2 = sodium.utils.hex2bin(hex: "de:ad be:ef", ignore: " :")
 ```

--- a/Sodium.xcodeproj/project.pbxproj
+++ b/Sodium.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		90C75EEC1AE3583E00F1E749 /* Sodium.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D80541A4ECCD7000B83F9 /* Sodium.swift */; };
 		90C75EED1AE3583E00F1E749 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D805C1A4F4F72000B83F9 /* Utils.swift */; };
 		CFD847281BA8120900B1260F /* PWHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097F20D91AF127480088C2FE /* PWHash.swift */; };
+		D85101041E22EF5B003DB2E8 /* ReadmeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85101031E22EF5B003DB2E8 /* ReadmeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -262,6 +263,8 @@
 		901645471AE37F7200163E3E /* Base.lproj */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Base.lproj; path = Examples/OSX/Base.lproj; sourceTree = "<group>"; };
 		90C75E941AE3571900F1E749 /* Sodium.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Sodium.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		90C75EAD1AE357CB00F1E749 /* libsodium-osx.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libsodium-osx.a"; sourceTree = "<group>"; };
+		D85101031E22EF5B003DB2E8 /* ReadmeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadmeTests.swift; sourceTree = "<group>"; };
+		D85101051E22F77E003DB2E8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -311,6 +314,7 @@
 		09A943BD1A4EB5F500C8A04F = {
 			isa = PBXGroup;
 			children = (
+				D85101051E22F77E003DB2E8 /* README.md */,
 				901644AF1AE36D6000163E3E /* Examples */,
 				09A943C91A4EB5F500C8A04F /* Sodium */,
 				09A943D61A4EB5F500C8A04F /* SodiumTests */,
@@ -362,6 +366,7 @@
 			isa = PBXGroup;
 			children = (
 				09A943D91A4EB5F500C8A04F /* SodiumTests.swift */,
+				D85101031E22EF5B003DB2E8 /* ReadmeTests.swift */,
 				09A943D71A4EB5F500C8A04F /* Supporting Files */,
 			);
 			path = SodiumTests;
@@ -842,6 +847,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				09A943DA1A4EB5F500C8A04F /* SodiumTests.swift in Sources */,
+				D85101041E22EF5B003DB2E8 /* ReadmeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SodiumTests/ReadmeTests.swift
+++ b/SodiumTests/ReadmeTests.swift
@@ -1,0 +1,150 @@
+//
+//  ReadmeTests.swift
+//  Sodium
+//
+//  Created by Joseph Ross on 1/8/17.
+//  Copyright © 2017 Joseph Ross. All rights reserved.
+//
+
+import XCTest
+import Sodium
+
+class ReadmeTests : XCTestCase {
+    func testAuthenticatedEncryption() {
+        let sodium = Sodium()!
+        let aliceKeyPair = sodium.box.keyPair()!
+        let bobKeyPair = sodium.box.keyPair()!
+        let message = "My Test Message".data(using:.utf8)!
+        
+        let encryptedMessageFromAliceToBob: NSData =
+            sodium.box.seal(message: message as NSData,
+                            recipientPublicKey: bobKeyPair.publicKey,
+                            senderSecretKey: aliceKeyPair.secretKey)!
+        
+        let messageVerifiedAndDecryptedByBob =
+            sodium.box.open(nonceAndAuthenticatedCipherText: encryptedMessageFromAliceToBob,
+                            senderPublicKey: aliceKeyPair.publicKey,
+                            recipientSecretKey: bobKeyPair.secretKey)
+    }
+    
+    func testAnonymousEncryptionSealedBoxes() {
+        let sodium = Sodium()!
+        let bobKeyPair = sodium.box.keyPair()!
+        let message = "My Test Message".data(using:.utf8)!
+        
+        let encryptedMessageToBob =
+            sodium.box.seal(message: message as NSData, recipientPublicKey: bobKeyPair.publicKey)!
+        
+        let messageDecryptedByBob =
+            sodium.box.open(anonymousCipherText: encryptedMessageToBob,
+                            recipientPublicKey: bobKeyPair.publicKey,
+                            recipientSecretKey: bobKeyPair.secretKey)
+    }
+    
+    func testDetachedSignatures() {
+        let sodium = Sodium()!
+        let message = "My Test Message".data(using:.utf8)!
+        let keyPair = sodium.sign.keyPair()!
+        let signature = sodium.sign.signature(message: message as NSData, secretKey: keyPair.secretKey)!
+        if sodium.sign.verify(message: message as NSData,
+                              publicKey: keyPair.publicKey,
+                              signature: signature) {
+            // signature is valid
+        }
+    }
+    
+    func testAttachedSignatures() {
+        let sodium = Sodium()!
+        let message = "My Test Message".data(using:.utf8)!
+        let keyPair = sodium.sign.keyPair()!
+        let signedMessage = sodium.sign.sign(message: message as NSData, secretKey: keyPair.secretKey)!
+        if let unsignedMessage = sodium.sign.open(signedMessage: signedMessage, publicKey: keyPair.publicKey) {
+            // signature is valid
+        }
+    }
+    
+    func testSecretKeyAuthenticatedEncryption() {
+        let sodium = Sodium()!
+        let message = "My Test Message".data(using:.utf8)!
+        let secretKey = sodium.secretBox.key()!
+        let encrypted: NSData = sodium.secretBox.seal(message: message as NSData, secretKey: secretKey)!
+        if let decrypted = sodium.secretBox.open(nonceAndAuthenticatedCipherText: encrypted, secretKey: secretKey) {
+            // authenticator is valid, decrypted contains the original message
+        }
+    }
+    
+    func testDeterministicHashing() {
+        let sodium = Sodium()!
+        let message = "My Test Message".data(using:.utf8)!
+        let h = sodium.genericHash.hash(message: message as NSData)
+    }
+    
+    func testKeyedHashing() {
+        let sodium = Sodium()!
+        let message = "My Test Message".data(using:.utf8)!
+        let key = "Secret key".data(using:.utf8)!
+        let h = sodium.genericHash.hash(message: message as NSData, key: key as NSData)
+    }
+    
+    func testStreaming() {
+        let sodium = Sodium()!
+        let message1 = "My Test ".data(using:.utf8)!
+        let message2 = "Message".data(using:.utf8)!
+        let key = "Secret key".data(using:.utf8)!
+        let stream = sodium.genericHash.initStream(key: key as NSData)!
+        stream.update(input: message1 as NSData)
+        stream.update(input: message2 as NSData)
+        let h = stream.final()
+    }
+    
+    func testShortOutputHashing() {
+        let sodium = Sodium()!
+        let message = "My Test Message".data(using:.utf8)!
+        let key = sodium.randomBytes.buf(length: sodium.shortHash.KeyBytes)!
+        let h = sodium.shortHash.hash(message: message as NSData, key: key as NSData)
+    }
+    
+    func testRandomNumberGeneration() {
+        let sodium = Sodium()!
+        let randomData = sodium.randomBytes.buf(length: 1000)
+    }
+    
+    func testPasswordHashing() {
+        let sodium = Sodium()!
+        let password = "Correct Horse Battery Staple".data(using:.utf8)!
+        let hashedStr = sodium.pwHash.str(passwd: password as NSData,
+                                          opsLimit: sodium.pwHash.OpsLimitInteractive,
+                                          memLimit: sodium.pwHash.MemLimitInteractive)!
+        
+        if sodium.pwHash.strVerify(hash: hashedStr, passwd: password as NSData) {
+            // Password matches the given hash string
+        } else {
+            // Password doesn't match the given hash string
+        }
+    }
+    
+    func testZeroingMemory() {
+        let sodium = Sodium()!
+        var dataToZero: NSMutableData = NSMutableData(data:"Message".data(using:.utf8)!)
+        sodium.utils.zero(data: dataToZero)
+    }
+    
+    func testConstantTimeComparison() {
+        let sodium = Sodium()!
+        let secret1: NSData = NSData(data:"Secret key".data(using:.utf8)!)
+        let secret2: NSData = NSData(data:"Secret key".data(using:.utf8)!)
+        let equality = sodium.utils.equals(b1: secret1, secret2)
+    }
+    
+    func testConstantTimeHexdecimalEncoding() {
+        let sodium = Sodium()!
+        let data: NSData = NSData(data:"Secret key".data(using:.utf8)!)
+        let hex = sodium.utils.bin2hex(bin: data)
+    }
+    
+    func testHexDecimalDecoding() {
+        let sodium = Sodium()!
+        let data1 = sodium.utils.hex2bin(hex: "deadbeef")
+        let data2 = sodium.utils.hex2bin(hex: "de:ad be:ef", ignore: " :")
+    }
+}


### PR DESCRIPTION
Update README.md examples so that they will compile.  Added ReadmeTests.swift to verify these snippets.

A lot of changes to the snippet include the addition of first argument names and " as NSData".  I know many of these are addressed in #48, and I'll be very happy to rebase and redo this PR if those changes are merged.