### PR TITLE
Reduce compiler warnings for example tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Deterministic hashing
 ```swift
 let sodium = Sodium()!
 let message = "My Test Message".data(using:.utf8)!
-let h = sodium.genericHash.hash(message: message )
+let h = sodium.genericHash.hash(message: message)
 ```
 
 Keyed hashing
@@ -153,7 +153,7 @@ Keyed hashing
 let sodium = Sodium()!
 let message = "My Test Message".data(using:.utf8)!
 let key = "Secret key".data(using:.utf8)!
-let h = sodium.genericHash.hash(message: message, key: key )
+let h = sodium.genericHash.hash(message: message, key: key)
 ```
 
 Streaming
@@ -164,9 +164,9 @@ let sodium = Sodium()!
 let message1 = "My Test ".data(using:.utf8)!
 let message2 = "Message".data(using:.utf8)!
 let key = "Secret key".data(using:.utf8)!
-let stream = sodium.genericHash.initStream(key: key )!
-stream.update(input: message1 )
-stream.update(input: message2 )
+let stream = sodium.genericHash.initStream(key: key)!
+stream.update(input: message1)
+stream.update(input: message2)
 let h = stream.final()
 ```
 
@@ -177,7 +177,7 @@ Short-output hashing (SipHash)
 let sodium = Sodium()!
 let message = "My Test Message".data(using:.utf8)!
 let key = sodium.randomBytes.buf(length: sodium.shortHash.KeyBytes)!
-let h = sodium.shortHash.hash(message: message, key: key )
+let h = sodium.shortHash.hash(message: message, key: key)
 ```
 
 Random numbers generation
@@ -200,7 +200,7 @@ let hashedStr = sodium.pwHash.str(passwd: password,
                                     opsLimit: sodium.pwHash.OpsLimitInteractive,
                                     memLimit: sodium.pwHash.MemLimitInteractive)!
 
-if sodium.pwHash.strVerify(hash: hashedStr, passwd: password ) {
+if sodium.pwHash.strVerify(hash: hashedStr, passwd: password) {
     // Password matches the given hash string
 } else {
     // Password doesn't match the given hash string

--- a/SodiumTests/ReadmeTests.swift
+++ b/SodiumTests/ReadmeTests.swift
@@ -25,6 +25,8 @@ class ReadmeTests : XCTestCase {
             sodium.box.open(nonceAndAuthenticatedCipherText: encryptedMessageFromAliceToBob,
                             senderPublicKey: aliceKeyPair.publicKey,
                             recipientSecretKey: bobKeyPair.secretKey)
+
+        XCTAssertNotNil(messageVerifiedAndDecryptedByBob)
     }
 
     func testAnonymousEncryptionSealedBoxes() {
@@ -39,6 +41,8 @@ class ReadmeTests : XCTestCase {
             sodium.box.open(anonymousCipherText: encryptedMessageToBob,
                             recipientPublicKey: bobKeyPair.publicKey,
                             recipientSecretKey: bobKeyPair.secretKey)
+
+        XCTAssertNotNil(messageDecryptedByBob)
     }
 
     func testDetachedSignatures() {
@@ -77,6 +81,8 @@ class ReadmeTests : XCTestCase {
         let sodium = Sodium()!
         let message = "My Test Message".data(using:.utf8)!
         let h = sodium.genericHash.hash(message: message)
+
+        XCTAssertNotNil(h)
     }
 
     func testKeyedHashing() {
@@ -84,6 +90,8 @@ class ReadmeTests : XCTestCase {
         let message = "My Test Message".data(using:.utf8)!
         let key = "Secret key".data(using:.utf8)!
         let h = sodium.genericHash.hash(message: message, key: key)
+
+        XCTAssertNotNil(h)
     }
 
     func testStreaming() {
@@ -95,6 +103,8 @@ class ReadmeTests : XCTestCase {
         stream.update(input: message1)
         stream.update(input: message2)
         let h = stream.final()
+
+        XCTAssertNotNil(h)
     }
 
     func testShortOutputHashing() {
@@ -102,11 +112,15 @@ class ReadmeTests : XCTestCase {
         let message = "My Test Message".data(using:.utf8)!
         let key = sodium.randomBytes.buf(length: sodium.shortHash.KeyBytes)!
         let h = sodium.shortHash.hash(message: message, key: key)
+
+        XCTAssertNotNil(h)
     }
 
     func testRandomNumberGeneration() {
         let sodium = Sodium()!
         let randomData = sodium.randomBytes.buf(length: 1000)
+
+        XCTAssertNotNil(randomData)
     }
 
     func testPasswordHashing() {
@@ -134,17 +148,24 @@ class ReadmeTests : XCTestCase {
         let secret1 = "Secret key".data(using:.utf8)!
         let secret2 = "Secret key".data(using:.utf8)!
         let equality = sodium.utils.equals(secret1, secret2)
+
+        XCTAssertTrue(equality)
     }
 
     func testConstantTimeHexdecimalEncoding() {
         let sodium = Sodium()!
         let data = "Secret key".data(using:.utf8)!
         let hex = sodium.utils.bin2hex(data)
+
+        XCTAssertNotNil(hex)
     }
 
     func testHexDecimalDecoding() {
         let sodium = Sodium()!
         let data1 = sodium.utils.hex2bin("deadbeef")
         let data2 = sodium.utils.hex2bin("de:ad be:ef", ignore: " :")
+
+        XCTAssertNotNil(data1)
+        XCTAssertNotNil(data2)
     }
 }

--- a/SodiumTests/ReadmeTests.swift
+++ b/SodiumTests/ReadmeTests.swift
@@ -76,14 +76,14 @@ class ReadmeTests : XCTestCase {
     func testDeterministicHashing() {
         let sodium = Sodium()!
         let message = "My Test Message".data(using:.utf8)!
-        let h = sodium.genericHash.hash(message: message )
+        let h = sodium.genericHash.hash(message: message)
     }
 
     func testKeyedHashing() {
         let sodium = Sodium()!
         let message = "My Test Message".data(using:.utf8)!
         let key = "Secret key".data(using:.utf8)!
-        let h = sodium.genericHash.hash(message: message, key: key )
+        let h = sodium.genericHash.hash(message: message, key: key)
     }
 
     func testStreaming() {
@@ -91,9 +91,9 @@ class ReadmeTests : XCTestCase {
         let message1 = "My Test ".data(using:.utf8)!
         let message2 = "Message".data(using:.utf8)!
         let key = "Secret key".data(using:.utf8)!
-        let stream = sodium.genericHash.initStream(key: key )!
-        stream.update(input: message1 )
-        stream.update(input: message2 )
+        let stream = sodium.genericHash.initStream(key: key)!
+        stream.update(input: message1)
+        stream.update(input: message2)
         let h = stream.final()
     }
 
@@ -101,7 +101,7 @@ class ReadmeTests : XCTestCase {
         let sodium = Sodium()!
         let message = "My Test Message".data(using:.utf8)!
         let key = sodium.randomBytes.buf(length: sodium.shortHash.KeyBytes)!
-        let h = sodium.shortHash.hash(message: message, key: key )
+        let h = sodium.shortHash.hash(message: message, key: key)
     }
 
     func testRandomNumberGeneration() {
@@ -116,7 +116,7 @@ class ReadmeTests : XCTestCase {
                                           opsLimit: sodium.pwHash.OpsLimitInteractive,
                                           memLimit: sodium.pwHash.MemLimitInteractive)!
 
-        if sodium.pwHash.strVerify(hash: hashedStr, passwd: password ) {
+        if sodium.pwHash.strVerify(hash: hashedStr, passwd: password) {
             // Password matches the given hash string
         } else {
             // Password doesn't match the given hash string


### PR DESCRIPTION
First I removed some empty spaces that where inconsistent with the rest of the code.

Second I added some `XCTAssert…()` statements to avoid warnings about unused variables for the tests for the example code. I only removed the warnings for examples without modifying them, so some superfluous warnings are still showing up.

I tried adding `-Wno-unused-variables` as a compiler flag to `ReadmeTests.swift` but this does not work for Swift 3 apparently (see multiple SO answers). 