### PR TITLE
Make Sodium() initializer nonfailable.

### DIFF
--- a/Examples/OSX/AppDelegate.swift
+++ b/Examples/OSX/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(aNotification: NSNotification) {
         // Insert code here to initialize your application
 
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let aliceKeyPair = sodium.box.keyPair()!
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".toData()!

--- a/Examples/iOS/ViewController.swift
+++ b/Examples/iOS/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
 
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let aliceKeyPair = sodium.box.keyPair()!
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".toData()!

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Authenticated Encryption
 ------------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let aliceKeyPair = sodium.box.keyPair()!
 let bobKeyPair = sodium.box.keyPair()!
 let message = "My Test Message".data(using:.utf8)!
@@ -69,7 +69,7 @@ Anonymous Encryption (Sealed Boxes)
 -----------------------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let bobKeyPair = sodium.box.keyPair()!
 let message = "My Test Message".data(using:.utf8)!
 
@@ -96,7 +96,7 @@ Detached signatures
 -------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message = "My Test Message".data(using:.utf8)!
 let keyPair = sodium.sign.keyPair()!
 let signature = sodium.sign.signature(message: message, secretKey: keyPair.secretKey)!
@@ -112,7 +112,7 @@ Attached signatures
 -------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message = "My Test Message".data(using:.utf8)!
 let keyPair = sodium.sign.keyPair()!
 let signedMessage = sodium.sign.sign(message: message, secretKey: keyPair.secretKey)!
@@ -125,7 +125,7 @@ Secret-key authenticated encryption
 ===================================
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message = "My Test Message".data(using:.utf8)!
 let secretKey = sodium.secretBox.key()!
 let encrypted: Data = sodium.secretBox.seal(message: message, secretKey: secretKey)!
@@ -141,7 +141,7 @@ Deterministic hashing
 ---------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message = "My Test Message".data(using:.utf8)!
 let h = sodium.genericHash.hash(message: message)
 ```
@@ -150,7 +150,7 @@ Keyed hashing
 -------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message = "My Test Message".data(using:.utf8)!
 let key = "Secret key".data(using:.utf8)!
 let h = sodium.genericHash.hash(message: message, key: key)
@@ -160,7 +160,7 @@ Streaming
 ---------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message1 = "My Test ".data(using:.utf8)!
 let message2 = "Message".data(using:.utf8)!
 let key = "Secret key".data(using:.utf8)!
@@ -174,7 +174,7 @@ Short-output hashing (SipHash)
 ==============================
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message = "My Test Message".data(using:.utf8)!
 let key = sodium.randomBytes.buf(length: sodium.shortHash.KeyBytes)!
 let h = sodium.shortHash.hash(message: message, key: key)
@@ -184,7 +184,7 @@ Random numbers generation
 =========================
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let randomData = sodium.randomBytes.buf(length: 1000)
 ```
 
@@ -194,7 +194,7 @@ Password hashing
 Using Argon2i:
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let password = "Correct Horse Battery Staple".data(using:.utf8)!
 let hashedStr = sodium.pwHash.str(passwd: password,
                                     opsLimit: sodium.pwHash.OpsLimitInteractive,
@@ -214,7 +214,7 @@ Zeroing memory
 --------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 var dataToZero = "Message".data(using:.utf8)!
 sodium.utils.zero(&dataToZero)
 ```
@@ -223,7 +223,7 @@ Constant-time comparison
 ------------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let secret1 = "Secret key".data(using:.utf8)!
 let secret2 = "Secret key".data(using:.utf8)!
 let equality = sodium.utils.equals(secret1, secret2)
@@ -233,7 +233,7 @@ Constant-time hexadecimal encoding
 ----------------------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let data = "Secret key".data(using:.utf8)!
 let hex = sodium.utils.bin2hex(data)
 ```
@@ -242,7 +242,7 @@ Hexadecimal decoding
 --------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let data1 = sodium.utils.hex2bin("deadbeef")
 let data2 = sodium.utils.hex2bin("de:ad be:ef", ignore: " :")
 ```

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -18,7 +18,7 @@ public class Sodium {
     public var sign = Sign()
     public var utils = Utils()
 
-    public init?() {
+    public init() {
         struct Once {
             static var once : () = {
                 if sodium_init() == -1 {

--- a/SodiumTests/ReadmeTests.swift
+++ b/SodiumTests/ReadmeTests.swift
@@ -11,7 +11,7 @@ import Sodium
 
 class ReadmeTests : XCTestCase {
     func testAuthenticatedEncryption() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let aliceKeyPair = sodium.box.keyPair()!
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".data(using:.utf8)!
@@ -30,7 +30,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testAnonymousEncryptionSealedBoxes() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".data(using:.utf8)!
 
@@ -46,7 +46,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testDetachedSignatures() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message = "My Test Message".data(using:.utf8)!
         let keyPair = sodium.sign.keyPair()!
         let signature = sodium.sign.signature(message: message, secretKey: keyPair.secretKey)!
@@ -58,7 +58,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testAttachedSignatures() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message = "My Test Message".data(using:.utf8)!
         let keyPair = sodium.sign.keyPair()!
         let signedMessage = sodium.sign.sign(message: message, secretKey: keyPair.secretKey)!
@@ -68,7 +68,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testSecretKeyAuthenticatedEncryption() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message = "My Test Message".data(using:.utf8)!
         let secretKey = sodium.secretBox.key()!
         let encrypted: Data = sodium.secretBox.seal(message: message, secretKey: secretKey)!
@@ -78,7 +78,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testDeterministicHashing() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message = "My Test Message".data(using:.utf8)!
         let h = sodium.genericHash.hash(message: message)
 
@@ -86,7 +86,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testKeyedHashing() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message = "My Test Message".data(using:.utf8)!
         let key = "Secret key".data(using:.utf8)!
         let h = sodium.genericHash.hash(message: message, key: key)
@@ -95,7 +95,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testStreaming() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message1 = "My Test ".data(using:.utf8)!
         let message2 = "Message".data(using:.utf8)!
         let key = "Secret key".data(using:.utf8)!
@@ -108,7 +108,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testShortOutputHashing() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message = "My Test Message".data(using:.utf8)!
         let key = sodium.randomBytes.buf(length: sodium.shortHash.KeyBytes)!
         let h = sodium.shortHash.hash(message: message, key: key)
@@ -117,14 +117,14 @@ class ReadmeTests : XCTestCase {
     }
 
     func testRandomNumberGeneration() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let randomData = sodium.randomBytes.buf(length: 1000)
 
         XCTAssertNotNil(randomData)
     }
 
     func testPasswordHashing() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let password = "Correct Horse Battery Staple".data(using:.utf8)!
         let hashedStr = sodium.pwHash.str(passwd: password,
                                           opsLimit: sodium.pwHash.OpsLimitInteractive,
@@ -138,13 +138,13 @@ class ReadmeTests : XCTestCase {
     }
 
     func testZeroingMemory() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         var dataToZero = "Message".data(using:.utf8)!
         sodium.utils.zero(&dataToZero)
     }
 
     func testConstantTimeComparison() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let secret1 = "Secret key".data(using:.utf8)!
         let secret2 = "Secret key".data(using:.utf8)!
         let equality = sodium.utils.equals(secret1, secret2)
@@ -153,7 +153,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testConstantTimeHexdecimalEncoding() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let data = "Secret key".data(using:.utf8)!
         let hex = sodium.utils.bin2hex(data)
 
@@ -161,7 +161,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testHexDecimalDecoding() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let data1 = sodium.utils.hex2bin("deadbeef")
         let data2 = sodium.utils.hex2bin("de:ad be:ef", ignore: " :")
 

--- a/SodiumTests/SodiumTests.swift
+++ b/SodiumTests/SodiumTests.swift
@@ -22,7 +22,7 @@ extension Data {
 }
 
 class SodiumTests: XCTestCase {
-    let sodium = Sodium(())!
+    let sodium = Sodium()
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
The Sodium initializer never actually returns nil, so I've marked it as unfailable.  This will remove the need for a forced unwrap or `if let` or `guard let` in code that uses this framework.

The other alternative would be to actually return nil if the call to `sodium_init()` fails.  I've prepared a commit that does that here: 55782c983d2b59a85e6e14e58cc2914ef76db63e.  There are other approaches to this since it is safe to call `sodium_init()` multiple times.

However, I prefer switching the existing implementation to a nonfailable initializer, allowing it to fatal error if `sodium_init()` fails.  Failure is very unlikely and difficult to recover from, and having the nonfailable initializer allows for tidier use of the Sodium object.