### PR TITLE
Make Sodium init properly failable.

### DIFF
--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -19,12 +19,8 @@ public class Sodium {
     public var utils = Utils()
 
     public init?() {
-        struct Once {
-            static var once : () = {
-                if sodium_init() == -1 {
-                    abort()
-                }
-            }()
+        if sodium_init() == -1 {
+            return nil
         }
     }
 }


### PR DESCRIPTION
There are a couple of ideas captured here:

First, if the initializer is failable, it should actually return `nil` when failure occurs, not crash the host application.  Returning nil gives the host application the opportunity to handle the error as it chooses.  It may be that many will choose to trigger a fatal error:
```
guard let sodium = Sodium() else {
    abort()
}
```
But the choice must be available.

Second, this commit prepares for the case in which a failed call to `sodium_init()` may recover in subsequent calls.  From the [libSodium docs](https://download.libsodium.org/doc/usage/):
> `sodium_init()` initializes the library and should be called before any other function provided by Sodium. The function can be called more than once, and can be called simultaneously from multiple threads since version 1.0.11.

> `sodium_init()` returns 0 on success, -1 on failure, and 1 if the library had already been initialized.