### PR TITLE
Add key exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,24 @@ if sodium.pwHash.strVerify(hash: hashedStr, passwd: password) {
 }
 ```
 
+Key exchange (Diffie Hellman)
+=============================
+
+```swift
+let sodium = Sodium()!
+let aliceKeyPair = sodium.box.keyPair()!
+let bobKeyPair = sodium.box.keyPair()!
+
+let sharedSecretForAlice = sodium.keyExchange.diffieHellman(secretKey: aliceKeyPair.secretKey,
+                                                            publicKey: aliceKeyPair.publicKey,
+                                                       otherPublicKey: bobKeyPair.publicKey)
+let sharedSecretForBob = sodium.keyExchange.diffieHellman(secretKey: bobKeyPair.secretKey,
+                                                          publicKey: bobKeyPair.publicKey,
+                                                     otherPublicKey: aliceKeyPair.publicKey)
+
+let equality = sodium.utils.equals(sharedSecretForAlice, sharedSecretForBob) // true
+```
+
 Utilities
 =========
 

--- a/Sodium.xcodeproj/project.pbxproj
+++ b/Sodium.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		09A944571A4EB91F00C8A04F /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 09A944231A4EB91F00C8A04F /* utils.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		09A944581A4EB91F00C8A04F /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = 09A944241A4EB91F00C8A04F /* version.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		09A9445A1A4EB97800C8A04F /* sodium_lib.h in Headers */ = {isa = PBXBuildFile; fileRef = 09A944591A4EB97800C8A04F /* sodium_lib.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7D4E43271E5BA91C005C9556 /* KeyExchange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4E43261E5BA91C005C9556 /* KeyExchange.swift */; };
+		7D4E43281E5BA91C005C9556 /* KeyExchange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4E43261E5BA91C005C9556 /* KeyExchange.swift */; };
 		901644FF1AE3733F00163E3E /* Sodium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90C75E941AE3571900F1E749 /* Sodium.framework */; };
 		901645011AE374D100163E3E /* Sodium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09A943C71A4EB5F500C8A04F /* Sodium.framework */; };
 		901645031AE376C100163E3E /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901645021AE376C100163E3E /* Helpers.swift */; };
@@ -243,6 +245,7 @@
 		09A944231A4EB91F00C8A04F /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
 		09A944241A4EB91F00C8A04F /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
 		09A944591A4EB97800C8A04F /* sodium_lib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sodium_lib.h; sourceTree = "<group>"; };
+		7D4E43261E5BA91C005C9556 /* KeyExchange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyExchange.swift; sourceTree = "<group>"; };
 		901644B61AE36EA700163E3E /* Example iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		901644DC1AE36F2D00163E3E /* Example OSX.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example OSX.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		901645021AE376C100163E3E /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Helpers.swift; path = Examples/CommonCode/Helpers.swift; sourceTree = "<group>"; };
@@ -346,6 +349,7 @@
 				091C7CDB1A50839D002E5351 /* Sign.swift */,
 				095D80541A4ECCD7000B83F9 /* Sodium.swift */,
 				095D805C1A4F4F72000B83F9 /* Utils.swift */,
+				7D4E43261E5BA91C005C9556 /* KeyExchange.swift */,
 			);
 			path = Sodium;
 			sourceTree = "<group>";
@@ -825,6 +829,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7D4E43271E5BA91C005C9556 /* KeyExchange.swift in Sources */,
 				095D80551A4ECCD7000B83F9 /* Sodium.swift in Sources */,
 				097F20DA1AF127480088C2FE /* PWHash.swift in Sources */,
 				038365151A5A51D20081136D /* SecretBox.swift in Sources */,
@@ -869,6 +874,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7D4E43281E5BA91C005C9556 /* KeyExchange.swift in Sources */,
 				90C75EE51AE3583E00F1E749 /* Box.swift in Sources */,
 				90C75EE61AE3583E00F1E749 /* SecretBox.swift in Sources */,
 				CFD847281BA8120900B1260F /* PWHash.swift in Sources */,

--- a/Sodium/KeyExchange.swift
+++ b/Sodium/KeyExchange.swift
@@ -1,0 +1,66 @@
+//
+//  KeyExchange.swift
+//  Sodium
+//
+//  Created by Andreas Ganske on 20.02.17.
+//  Copyright © 2017 Frank Denis. All rights reserved.
+//
+
+import Foundation
+
+public class KeyExchange {
+    public let PublicKeyBytes = Int(crypto_box_publickeybytes())
+    public let SecretKeyBytes = Int(crypto_box_secretkeybytes())
+    public let SecretBytes = Int(crypto_scalarmult_bytes())
+    public let Bytes = Int(crypto_hash_bytes())
+    
+    /**
+     This function can be used to compute a shared secret given a user's secret key and another user's public key.
+     See https://download.libsodium.org/doc/advanced/scalar_multiplication.html for more details.
+     
+     - Parameter secretKey: The secret key to use in diffie hellman key exchange
+     - Parameter publicKey: The public key used in conjunction with the other public key to hash the computed secret
+     - Parameter otherPublicKey: The other user's public key to use in diffie hellman key exchange
+     
+     - Returns: The computed shared secret
+     */
+    public func diffieHellman(secretKey: Box.SecretKey, publicKey: Box.PublicKey, otherPublicKey: Box.PublicKey) -> Data? {
+        
+        if secretKey.count != SecretKeyBytes || otherPublicKey.count != PublicKeyBytes {
+            return nil
+        }
+        
+        var output = Data(count: SecretBytes)
+        var result: Int32 = -1
+        
+        result = output.withUnsafeMutableBytes { outputPtr in
+            return secretKey.withUnsafeBytes { secretKeyPtr in
+                return otherPublicKey.withUnsafeBytes { otherPublicKeyPtr in
+                    return crypto_scalarmult(outputPtr, secretKeyPtr, otherPublicKeyPtr)
+                }
+            }
+        }
+        
+        if result != 0 {
+            return nil
+        }
+        
+        // Don't use the result yet because the number of possible keys is limited to the group size (≈2^252), and the key distribution is not uniform. So we use h( ouput || pk1 || pk2) as recommended by https://download.libsodium.org/doc/advanced/scalar_multiplication.html
+        var bytes = Data(count: Bytes)
+        
+        guard let stream = GenericHash.Stream(key: nil, outputLength: bytes.count) else {
+            return nil
+        }
+        
+        // We have to choose in which order the public keys are concatenated, so we order them lexicographically (comparing byte by byte)
+        let publicKeys = [publicKey, otherPublicKey].sorted(by: { (lhs, rhs) in
+            return lhs.lexicographicallyPrecedes(rhs)
+        })
+        
+        if !stream.update(input: output) { return nil }
+        if !stream.update(input: publicKeys[0]) { return nil }
+        if !stream.update(input: publicKeys[1]) { return nil }
+        
+        return stream.final()
+    }
+}

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -17,6 +17,7 @@ public class Sodium {
     public var shortHash = ShortHash()
     public var sign = Sign()
     public var utils = Utils()
+    public var keyExchange = KeyExchange()
 
     public init?() {
         struct Once {

--- a/SodiumTests/SodiumTests.swift
+++ b/SodiumTests/SodiumTests.swift
@@ -242,4 +242,14 @@ class SodiumTests: XCTestCase {
         let hash2 = sodium.pwHash.hash(outputLength: 64, passwd: password3, salt: salt, opsLimit: sodium.pwHash.OpsLimitInteractive, memLimit: sodium.pwHash.MemLimitInteractive)
         XCTAssert(sodium.utils.bin2hex(hash2!)! == "51d659ee6f8790042688274c5bc8a6296390cdc786d2341c3553b01a5c3f7ff1190e04b86a878538b17ef10e74baa19295479f3e3ee587ce571f366fc66e2fdc")
     }
+    
+    func testKeyExchange() {
+        let aliceKeyPair = sodium.box.keyPair()!
+        let bobKeyPair = sodium.box.keyPair()!
+        
+        let sharedSecretForAlice = sodium.keyExchange.diffieHellman(secretKey: aliceKeyPair.secretKey, publicKey: aliceKeyPair.publicKey, otherPublicKey: bobKeyPair.publicKey)
+        let sharedSecretForBob = sodium.keyExchange.diffieHellman(secretKey: bobKeyPair.secretKey, publicKey: bobKeyPair.publicKey, otherPublicKey: aliceKeyPair.publicKey)
+        
+        XCTAssert(sharedSecretForAlice == sharedSecretForBob)
+    }
 }


### PR DESCRIPTION
This adds the key exchange functionality of libsodium to swift-sodium.

As I wanted to keep the structure of lib sodium, this PR introduces a new class `KeyExchange` with the following method:
```
func diffieHellman(secretKey: Box.SecretKey, publicKey: Box.PublicKey, otherPublicKey: Box.PublicKey) -> Data?
```
which takes the parameters:

`secretKey`: The secret key to use in diffie hellman key exchange
`publicKey`: The public key used in conjunction with the other public key to hash the computed secret
`otherPublicKey`: The other user's public key to use in diffie hellman key exchange

I added a test for this method and updated the README to contain a code snippet.
This also solves #58.

For more information on the key exchange via Diffie-Hellman, have a look at [Libsodium reference](https://download.libsodium.org/doc/advanced/scalar_multiplication.html).