### PR TITLE
Add key exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,21 @@ if sodium.pwHash.strVerify(hash: hashedStr, passwd: password) {
 }
 ```
 
+Key exchange
+============
+
+```swift
+let sodium = Sodium()!
+let aliceKeyPair = sodium.keyExchange.keyPair()!
+let bobKeyPair = sodium.keyExchange.keyPair()!
+
+let sessionKeyPairForAlice = sodium.keyExchange.sessionKeyPair(publicKey: aliceKeyPair.publicKey, secretKey: aliceKeyPair.secretKey, otherPublicKey: bobKeyPair.publicKey, side: .client)!
+let sessionKeyPairForBob = sodium.keyExchange.sessionKeyPair(publicKey: bobKeyPair.publicKey, secretKey: bobKeyPair.secretKey, otherPublicKey: aliceKeyPair.publicKey, side: .server)!
+
+let aliceToBobKeyEquality = sodium.utils.equals(sessionKeyPairForAlice.tx, sessionKeyPairForBob.xx) // true
+let bobToAliceKeyEquality = sodium.utils.equals(sessionKeyPairForAlice.rx, sessionKeyPairForBob.tx) // true
+```
+
 Utilities
 =========
 

--- a/Sodium.xcodeproj/project.pbxproj
+++ b/Sodium.xcodeproj/project.pbxproj
@@ -88,6 +88,8 @@
 		09BB143C1E75CA6F00659F17 /* crypto_secretbox_xchacha20poly1305.h in Headers */ = {isa = PBXBuildFile; fileRef = 09BB142F1E75CA6F00659F17 /* crypto_secretbox_xchacha20poly1305.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		09BB143D1E75CA6F00659F17 /* crypto_stream_xchacha20.h in Headers */ = {isa = PBXBuildFile; fileRef = 09BB14301E75CA6F00659F17 /* crypto_stream_xchacha20.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		09BB143E1E75CA6F00659F17 /* crypto_stream_xchacha20.h in Headers */ = {isa = PBXBuildFile; fileRef = 09BB14301E75CA6F00659F17 /* crypto_stream_xchacha20.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7D6373E21E7B5E0800F04E72 /* KeyExchange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6373E11E7B5E0800F04E72 /* KeyExchange.swift */; };
+		7D6373E31E7B6C6E00F04E72 /* KeyExchange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6373E11E7B5E0800F04E72 /* KeyExchange.swift */; };
 		901644FF1AE3733F00163E3E /* Sodium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90C75E941AE3571900F1E749 /* Sodium.framework */; };
 		901645011AE374D100163E3E /* Sodium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09A943C71A4EB5F500C8A04F /* Sodium.framework */; };
 		901645031AE376C100163E3E /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901645021AE376C100163E3E /* Helpers.swift */; };
@@ -246,6 +248,7 @@
 		09BB142E1E75CA6F00659F17 /* crypto_kx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_kx.h; sourceTree = "<group>"; };
 		09BB142F1E75CA6F00659F17 /* crypto_secretbox_xchacha20poly1305.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_secretbox_xchacha20poly1305.h; sourceTree = "<group>"; };
 		09BB14301E75CA6F00659F17 /* crypto_stream_xchacha20.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_stream_xchacha20.h; sourceTree = "<group>"; };
+		7D6373E11E7B5E0800F04E72 /* KeyExchange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyExchange.swift; sourceTree = "<group>"; };
 		901644B61AE36EA700163E3E /* Example iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		901644DC1AE36F2D00163E3E /* Example OSX.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example OSX.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		901645021AE376C100163E3E /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Helpers.swift; path = Examples/CommonCode/Helpers.swift; sourceTree = "<group>"; };
@@ -349,6 +352,7 @@
 				091C7CDB1A50839D002E5351 /* Sign.swift */,
 				095D80541A4ECCD7000B83F9 /* Sodium.swift */,
 				095D805C1A4F4F72000B83F9 /* Utils.swift */,
+				7D6373E11E7B5E0800F04E72 /* KeyExchange.swift */,
 			);
 			path = Sodium;
 			sourceTree = "<group>";
@@ -831,6 +835,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7D6373E21E7B5E0800F04E72 /* KeyExchange.swift in Sources */,
 				095D80551A4ECCD7000B83F9 /* Sodium.swift in Sources */,
 				097F20DA1AF127480088C2FE /* PWHash.swift in Sources */,
 				038365151A5A51D20081136D /* SecretBox.swift in Sources */,
@@ -875,6 +880,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7D6373E31E7B6C6E00F04E72 /* KeyExchange.swift in Sources */,
 				90C75EE51AE3583E00F1E749 /* Box.swift in Sources */,
 				90C75EE61AE3583E00F1E749 /* SecretBox.swift in Sources */,
 				CFD847281BA8120900B1260F /* PWHash.swift in Sources */,

--- a/Sodium/KeyExchange.swift
+++ b/Sodium/KeyExchange.swift
@@ -1,0 +1,145 @@
+//
+//  KeyExchange.swift
+//  Sodium
+//
+//  Created by Andreas Ganske on 17.03.17.
+//  Copyright © 2017 Frank Denis. All rights reserved.
+//
+
+import Foundation
+
+public class KeyExchange {
+    
+    public let PublicKeyBytes = Int(crypto_kx_publickeybytes())
+    public let SecretKeyBytes = Int(crypto_kx_secretkeybytes())
+    public let SessionKeyBytes = Int(crypto_kx_sessionkeybytes())
+    public let SeedBytes = Int(crypto_kx_seedbytes())
+    
+    public typealias PublicKey = Data
+    public typealias SecretKey = Data
+    
+    public struct KeyPair {
+        public let publicKey: PublicKey
+        public let secretKey: SecretKey
+        
+        public init(publicKey: PublicKey, secretKey: SecretKey) {
+            self.publicKey = publicKey
+            self.secretKey = secretKey
+        }
+    }
+    
+    public struct SessionKeyPair {
+        public let rx: Data
+        public let tx: Data
+        
+        public init(rx: Data, tx: Data) {
+            self.rx = rx
+            self.tx = tx
+        }
+    }
+    
+    public enum Side {
+        case client
+        case server
+    }
+    
+    /**
+     Randomly generates a key exchange secret key and a corresponding public key.
+     
+     - Returns: A key pair containing the secret key and public key.
+     */
+    public func keyPair() -> KeyPair? {
+        
+        var publicKey = Data(count: PublicKeyBytes)
+        var secretKey = Data(count: SecretKeyBytes)
+        
+        var result: Int32 = -1
+        result = publicKey.withUnsafeMutableBytes { publicKeyPtr in
+            return secretKey.withUnsafeMutableBytes { secretKeyPtr in
+                return crypto_kx_keypair(publicKeyPtr, secretKeyPtr)
+            }
+        }
+        
+        guard result == 0 else {
+            return nil
+        }
+        
+        return KeyPair(publicKey: publicKey, secretKey: secretKey)
+    }
+    
+    /**
+     Generates a key exchange secret key and a corresponding public key based on a provided seed value
+     
+     - Parameter seed: The value from which to derive the secret and public key.
+     
+     - Returns: A key pair containing the secret key and public key.
+     */
+    public func keyPair(seed: Data) -> KeyPair? {
+        
+        if seed.count != SeedBytes {
+            return nil
+        }
+        
+        var pk = Data(count: PublicKeyBytes)
+        var sk = Data(count: SecretKeyBytes)
+        
+        let result = pk.withUnsafeMutableBytes { pkPtr in
+            return sk.withUnsafeMutableBytes { skPtr in
+                return seed.withUnsafeBytes { seedPtr in
+                    return crypto_kx_seed_keypair(pkPtr, skPtr, seedPtr)
+                }
+            }
+        }
+        
+        if result != 0 {
+            return nil
+        }
+        
+        return KeyPair(publicKey: pk, secretKey: sk)
+    }
+    
+    /**
+     Using this function, two parties can securely compute a set of shared keys using their peer's public key and their own secret key.
+     See [libsodium.org/doc/key_exchange](https://download.libsodium.org/doc/key_exchange) for more details.
+     
+     - Parameter publicKey: The public key used for the key exchange
+     - Parameter secretKey: The secret key to used for the key exchange
+     - Parameter otherPublicKey: The peer's public key for the key exchange
+     - Parameter side: Side (`client` or `host`) on which the key exchange is run
+     
+     - Returns: A `SessionKeyPair` consisting of a receive (`rx`) key and a transmit (`tx`) key
+     
+     - Note: `rx` on client side equals `tx` on server side and vice versa
+     */
+    public func sessionKeyPair(publicKey: PublicKey, secretKey: SecretKey, otherPublicKey: PublicKey, side: Side) -> SessionKeyPair? {
+        
+        if publicKey.count != PublicKeyBytes ||
+           secretKey.count != SecretKeyBytes ||
+           otherPublicKey.count != PublicKeyBytes {
+            return nil
+        }
+        
+        var rx = Data(count: SessionKeyBytes)
+        var tx = Data(count: SessionKeyBytes)
+        
+        let session_keys = (side == .client) ? crypto_kx_client_session_keys : crypto_kx_server_session_keys
+        
+        let result = rx.withUnsafeMutableBytes { rxPtr in
+            return tx.withUnsafeMutableBytes { txPtr in
+                return secretKey.withUnsafeBytes { secretKeyPtr in
+                    return publicKey.withUnsafeBytes { publicKeyPtr in
+                        return otherPublicKey.withUnsafeBytes { otherPublicKeyPtr in
+                            return session_keys(rxPtr, txPtr, publicKeyPtr, secretKeyPtr, otherPublicKeyPtr)
+                        }
+                    }
+                }
+            }
+        }
+        
+        if result != 0 {
+            return nil
+        }
+        
+        return SessionKeyPair(rx: rx, tx: tx)
+    }
+}

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -17,6 +17,7 @@ public class Sodium {
     public var shortHash = ShortHash()
     public var sign = Sign()
     public var utils = Utils()
+    public var keyExchange = KeyExchange()
 
     public init?() {
         struct Once {

--- a/SodiumTests/SodiumTests.swift
+++ b/SodiumTests/SodiumTests.swift
@@ -242,4 +242,16 @@ class SodiumTests: XCTestCase {
         let hash2 = sodium.pwHash.hash(outputLength: 64, passwd: password3, salt: salt, opsLimit: sodium.pwHash.OpsLimitInteractive, memLimit: sodium.pwHash.MemLimitInteractive)
         XCTAssert(sodium.utils.bin2hex(hash2!)! == "51d659ee6f8790042688274c5bc8a6296390cdc786d2341c3553b01a5c3f7ff1190e04b86a878538b17ef10e74baa19295479f3e3ee587ce571f366fc66e2fdc")
     }
+    
+    func testKeyExchange() {
+        let aliceKeyPair = sodium.keyExchange.keyPair()!
+        let bobKeyPair = sodium.keyExchange.keyPair()!
+        
+        let sessionKeyPairForAlice = sodium.keyExchange.sessionKeyPair(publicKey: aliceKeyPair.publicKey, secretKey: aliceKeyPair.secretKey, otherPublicKey: bobKeyPair.publicKey, side: .client)!
+        let sessionKeyPairForBob = sodium.keyExchange.sessionKeyPair(publicKey: bobKeyPair.publicKey, secretKey: bobKeyPair.secretKey, otherPublicKey: aliceKeyPair.publicKey, side: .server)!
+        
+        XCTAssert(sessionKeyPairForAlice.rx == sessionKeyPairForBob.tx)
+        XCTAssert(sessionKeyPairForAlice.tx == sessionKeyPairForBob.rx)
+    }
+
 }


### PR DESCRIPTION
This adds the key exchange functionality of libsodium to swift-sodium.

As I wanted to keep the structure of lib sodium, this PR introduces a new class KeyExchange with the following method:

```
func sessionKeyPair(publicKey: PublicKey, secretKey: SecretKey, otherPublicKey: PublicKey, side: Side) -> SessionKeyPair?
```

See https://github.com/jedisct1/swift-sodium/pull/60 and [libsodium.org/doc/key_exchange](https://download.libsodium.org/doc/key_exchange/)