### PR TITLE
Collect coverage data from unit tests

### DIFF
--- a/Sodium.xcodeproj/xcshareddata/xcschemes/Sodium.xcscheme
+++ b/Sodium.xcodeproj/xcshareddata/xcschemes/Sodium.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
I think it is safe and useful to enable this for unit tests.