### PR TITLE
fixes podspec source paths

### DIFF
--- a/Sodium.podspec
+++ b/Sodium.podspec
@@ -12,10 +12,10 @@ s.source = { :git => 'https://github.com/jedisct1/swift-sodium.git',
 s.ios.deployment_target = '8.0'
 s.osx.deployment_target = '10.10'
 
-s.ios.vendored_library    = 'Sodium/libsodium-ios.a'
-s.osx.vendored_library    = 'Sodium/libsodium-osx.a'
+s.ios.vendored_library    = 'Sodium/libsodium/libsodium-ios.a'
+s.osx.vendored_library    = 'Sodium/libsodium/libsodium-osx.a'
 
-s.source_files = 'Sodium/*.{swift,h}'
+s.source_files = 'Sodium/*.{swift,h}', 'Sodium/libsodium/*.{swift,h}'
 
 s.requires_arc = true
 end


### PR DESCRIPTION
see issue #75 

This pull-request should fix missing files by using Pods, since the libsodium core was moved from `Sodium` to `Sodium/libsodium`.