### PR TITLE
fixes build-issues using Cocoa Pods

### DIFF
--- a/Sodium.podspec
+++ b/Sodium.podspec
@@ -17,6 +17,7 @@ s.osx.vendored_library    = 'Sodium/libsodium/libsodium-osx.a'
 
 s.source_files = 'Sodium/*.{swift,h}', 'Sodium/libsodium/*.{swift,h}'
 
+s.preserve_paths = 'Sodium/libsodium/module.modulemap'
 s.pod_target_xcconfig = {
 	'SWIFT_INCLUDE_PATHS' => '$(PODS_TARGET_SRCROOT)/Sodium/libsodium',
 }

--- a/Sodium.podspec
+++ b/Sodium.podspec
@@ -17,5 +17,9 @@ s.osx.vendored_library    = 'Sodium/libsodium/libsodium-osx.a'
 
 s.source_files = 'Sodium/*.{swift,h}', 'Sodium/libsodium/*.{swift,h}'
 
+s.pod_target_xcconfig = {
+	'SWIFT_INCLUDE_PATHS' => '$(PODS_TARGET_SRCROOT)/Sodium/libsodium',
+}
+
 s.requires_arc = true
 end


### PR DESCRIPTION
Sadly the proposed solution from #77 did not work for Cocoa-Pods, but the Idea was the right one.
The Podspec file just had to adapt the fixed `SWIFT_INCLUDE_PATHS`.

This should now solve all build issues with CocoaPods. Original issue see #75.