### PR TITLE
add `Box.open()` overload that takes a user-specified nonce

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ let messageVerifiedAndDecryptedByBob =
 
 `seal()` automatically generates a nonce and prepends it to the
 ciphertext. `open()` extracts the nonce and decrypts the ciphertext.
+Optionally, `Box` provides the ability to utilize a user-defined nonce via
+`seal(message:recipientPublicKey:senderSecretKey:nonce:)`.
+
 
 The `Box` class also provides alternative functions and parameters to
 deterministically generate key pairs, to retrieve the nonce and/or the

--- a/SodiumTests/SodiumTests.swift
+++ b/SodiumTests/SodiumTests.swift
@@ -49,10 +49,15 @@ class SodiumTests: XCTestCase {
         let decrypted3 = sodium.box.open(authenticatedCipherText: encryptedMessageFromAliceToBob3, senderPublicKey: aliceKeyPair.publicKey, recipientSecretKey: bobKeyPair.secretKey, nonce: nonce2, mac: mac)
         XCTAssertEqual(decrypted3, message)
 
+        let userNonce = sodium.randomBytes.buf(length: 24)!
+        let encryptedMessageFromAliceToBob4: Data = sodium.box.seal(message: message, recipientPublicKey: bobKeyPair.publicKey, senderSecretKey: aliceKeyPair.secretKey, nonce: userNonce)!
+        let decrypted4 = sodium.box.open(authenticatedCipherText: encryptedMessageFromAliceToBob4, senderPublicKey: bobKeyPair.publicKey, recipientSecretKey: aliceKeyPair.secretKey, nonce: userNonce)
+        XCTAssertEqual(message, decrypted4)
+
         let encryptedMessageToBob: Data = sodium.box.seal(message: message, recipientPublicKey: bobKeyPair.publicKey)!
-        let decrypted4 = sodium.box.open(anonymousCipherText: encryptedMessageToBob, recipientPublicKey: bobKeyPair.publicKey,
+        let decrypted5 = sodium.box.open(anonymousCipherText: encryptedMessageToBob, recipientPublicKey: bobKeyPair.publicKey,
             recipientSecretKey: bobKeyPair.secretKey)
-        XCTAssertEqual(decrypted4, message)
+        XCTAssertEqual(decrypted5, message)
 
         // beforenm tests
         // The two beforenm keys calculated by Alice and Bob separately should be identical


### PR DESCRIPTION
It's been a breeze to work with swift-sodium. Thanks so much for your work.

I am working on a BLE encryption for which the peer device requires a very specific nonce. This PR adds the ability to swift-sodium's `Box` for a user to provide his own nonce instead of relying on `self.nonce()` to generate a random encryption nonce.

Thanks!