### PR TITLE
Improve Sodium's initializer

### DIFF
--- a/Examples/OSX/AppDelegate.swift
+++ b/Examples/OSX/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(aNotification: NSNotification) {
         // Insert code here to initialize your application
 
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let aliceKeyPair = sodium.box.keyPair()!
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".toData()!

--- a/Examples/iOS/ViewController.swift
+++ b/Examples/iOS/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
 
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let aliceKeyPair = sodium.box.keyPair()!
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".toData()!

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Anonymous Encryption (Sealed Boxes)
 -----------------------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let bobKeyPair = sodium.box.keyPair()!
 let message = "My Test Message".data(using:.utf8)!
 
@@ -100,7 +100,7 @@ Detached signatures
 -------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message = "My Test Message".data(using:.utf8)!
 let keyPair = sodium.sign.keyPair()!
 let signature = sodium.sign.signature(message: message, secretKey: keyPair.secretKey)!
@@ -115,7 +115,7 @@ Attached signatures
 -------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message = "My Test Message".data(using:.utf8)!
 let keyPair = sodium.sign.keyPair()!
 let signedMessage = sodium.sign.sign(message: message, secretKey: keyPair.secretKey)!
@@ -128,7 +128,7 @@ Secret-key authenticated encryption
 ===================================
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message = "My Test Message".data(using:.utf8)!
 let secretKey = sodium.secretBox.key()!
 let encrypted: Data = sodium.secretBox.seal(message: message, secretKey: secretKey)!
@@ -144,7 +144,7 @@ Deterministic hashing
 ---------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message = "My Test Message".data(using:.utf8)!
 let h = sodium.genericHash.hash(message: message)
 ```
@@ -153,7 +153,7 @@ Keyed hashing
 -------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message = "My Test Message".data(using:.utf8)!
 let key = "Secret key".data(using:.utf8)!
 let h = sodium.genericHash.hash(message: message, key: key)
@@ -163,7 +163,7 @@ Streaming
 ---------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message1 = "My Test ".data(using:.utf8)!
 let message2 = "Message".data(using:.utf8)!
 let key = "Secret key".data(using:.utf8)!
@@ -177,7 +177,7 @@ Short-output hashing (SipHash)
 ==============================
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let message = "My Test Message".data(using:.utf8)!
 let key = sodium.randomBytes.buf(length: sodium.shortHash.KeyBytes)!
 let h = sodium.shortHash.hash(message: message, key: key)
@@ -187,7 +187,7 @@ Random numbers generation
 =========================
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let randomData = sodium.randomBytes.buf(length: 1000)!
 let seed = "0123456789abcdef0123456789abcdef".data(using:.utf8)!
 let stream = sodium.randomBytes.deterministic(length: 1000, seed: seed)!
@@ -199,7 +199,7 @@ Password hashing
 Using Argon2i:
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let password = "Correct Horse Battery Staple".data(using:.utf8)!
 let hashedStr = sodium.pwHash.str(passwd: password,
                                   opsLimit: sodium.pwHash.OpsLimitInteractive,
@@ -216,7 +216,7 @@ Key exchange
 ============
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let aliceKeyPair = sodium.keyExchange.keyPair()!
 let bobKeyPair = sodium.keyExchange.keyPair()!
 
@@ -242,7 +242,7 @@ computing and verifying a tag. Therefore, verifiers can also compute
 tags for arbitrary messages.
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let input = "test".data(using:.utf8)!
 let key = sodium.auth.key()!
 let tag = sodium.auth.tag(message: input, secretKey: key)!
@@ -258,7 +258,7 @@ context. Up to (2^64) - 1 subkeys can be generated for each context,
 by incrementing the index.
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let secretKey = sodium.keyDerivation.keygen()!
 
 let subKey1 = sodium.keyDerivation.derive(secretKey: secretKey,
@@ -276,7 +276,7 @@ Zeroing memory
 --------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 var dataToZero = "Message".data(using:.utf8)!
 sodium.utils.zero(&dataToZero)
 ```
@@ -285,7 +285,7 @@ Constant-time comparison
 ------------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let secret1 = "Secret key".data(using:.utf8)!
 let secret2 = "Secret key".data(using:.utf8)!
 let equality = sodium.utils.equals(secret1, secret2)
@@ -295,7 +295,7 @@ Constant-time hexadecimal encoding
 ----------------------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let data = "Secret key".data(using:.utf8)!
 let hex = sodium.utils.bin2hex(data)
 ```
@@ -304,7 +304,7 @@ Hexadecimal decoding
 --------------------
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let data1 = sodium.utils.hex2bin("deadbeef")
 let data2 = sodium.utils.hex2bin("de:ad be:ef", ignore: " :")
 ```
@@ -334,7 +334,7 @@ In order to generate a deterministic stream out of a seed, the
 need.
 
 ```swift
-let sodium = Sodium()!
+let sodium = Sodium()
 let input = "test".data(using:.utf8)!
 let key = sodium.stream.key()!
 let (output, nonce) = sodium.stream.xor(input: input, secretKey: key)!

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -22,14 +22,14 @@ public class Sodium {
     public let auth = Auth()
     public let stream = Stream()
         public let keyDerivation = KeyDerivation()
-
-    public init?() {
-        struct Once {
-            static var once : () = {
-                if sodium_init() == -1 {
-                    abort()
-                }
-            }()
+    
+    private static let once: Void = {
+        if sodium_init() == -1 {
+            fatalError("Failed to initialize libSodium")
         }
+    }()
+    
+    public init() {
+        _ = Sodium.once
     }
 }

--- a/SodiumTests/ReadmeTests.swift
+++ b/SodiumTests/ReadmeTests.swift
@@ -11,7 +11,7 @@ import Sodium
 
 class ReadmeTests : XCTestCase {
     func testAuthenticatedEncryption() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let aliceKeyPair = sodium.box.keyPair()!
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".data(using:.utf8)!
@@ -30,7 +30,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testAnonymousEncryptionSealedBoxes() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".data(using:.utf8)!
 
@@ -46,7 +46,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testDetachedSignatures() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message = "My Test Message".data(using:.utf8)!
         let keyPair = sodium.sign.keyPair()!
         let signature = sodium.sign.signature(message: message, secretKey: keyPair.secretKey)!
@@ -58,7 +58,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testAttachedSignatures() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message = "My Test Message".data(using:.utf8)!
         let keyPair = sodium.sign.keyPair()!
         let signedMessage = sodium.sign.sign(message: message, secretKey: keyPair.secretKey)!
@@ -68,7 +68,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testSecretKeyAuthenticatedEncryption() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message = "My Test Message".data(using:.utf8)!
         let secretKey = sodium.secretBox.key()!
         let encrypted: Data = sodium.secretBox.seal(message: message, secretKey: secretKey)!
@@ -78,7 +78,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testDeterministicHashing() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message = "My Test Message".data(using:.utf8)!
         let h = sodium.genericHash.hash(message: message)
 
@@ -86,7 +86,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testKeyedHashing() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message = "My Test Message".data(using:.utf8)!
         let key = "Secret key".data(using:.utf8)!
         let h = sodium.genericHash.hash(message: message, key: key)
@@ -95,7 +95,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testStreaming() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message1 = "My Test ".data(using:.utf8)!
         let message2 = "Message".data(using:.utf8)!
         let key = "Secret key".data(using:.utf8)!
@@ -108,7 +108,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testShortOutputHashing() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let message = "My Test Message".data(using:.utf8)!
         let key = sodium.randomBytes.buf(length: sodium.shortHash.KeyBytes)!
         let h = sodium.shortHash.hash(message: message, key: key)
@@ -117,14 +117,14 @@ class ReadmeTests : XCTestCase {
     }
 
     func testRandomNumberGeneration() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let randomData = sodium.randomBytes.buf(length: 1000)
 
         XCTAssertNotNil(randomData)
     }
 
     func testPasswordHashing() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let password = "Correct Horse Battery Staple".data(using:.utf8)!
         let hashedStr = sodium.pwHash.str(passwd: password,
                                           opsLimit: sodium.pwHash.OpsLimitInteractive,
@@ -138,13 +138,13 @@ class ReadmeTests : XCTestCase {
     }
 
     func testZeroingMemory() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         var dataToZero = "Message".data(using:.utf8)!
         sodium.utils.zero(&dataToZero)
     }
 
     func testConstantTimeComparison() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let secret1 = "Secret key".data(using:.utf8)!
         let secret2 = "Secret key".data(using:.utf8)!
         let equality = sodium.utils.equals(secret1, secret2)
@@ -153,7 +153,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testConstantTimeHexdecimalEncoding() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let data = "Secret key".data(using:.utf8)!
         let hex = sodium.utils.bin2hex(data)
 
@@ -161,7 +161,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testHexDecimalDecoding() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let data1 = sodium.utils.hex2bin("deadbeef")
         let data2 = sodium.utils.hex2bin("de:ad be:ef", ignore: " :")
 
@@ -170,7 +170,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testStream() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let input = "test".data(using:.utf8)!
         let key = sodium.stream.key()!
         let (output, nonce) = sodium.stream.xor(input: input, secretKey: key)!
@@ -180,7 +180,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testAuth() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let input = "test".data(using:.utf8)!
         let key = sodium.auth.key()!
         let tag = sodium.auth.tag(message: input, secretKey: key)!
@@ -190,7 +190,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testKeyDerivation() {
-        let sodium = Sodium()!
+        let sodium = Sodium()
         let secretKey = sodium.keyDerivation.key()!
 
         let subKey1 = sodium.keyDerivation.derive(secretKey: secretKey,

--- a/SodiumTests/SodiumTests.swift
+++ b/SodiumTests/SodiumTests.swift
@@ -22,7 +22,7 @@ extension Data {
 }
 
 class SodiumTests: XCTestCase {
-    let sodium = Sodium()!
+    let sodium = Sodium()
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
@jedisct1 Since the original initializer calls **abort()** when **sodium_init()** returns -1, we can make the initializer non-optional.