### PR TITLE
Return non-optional key if keygen is guaranteed to succeed (with docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ let message1 = "Message 1".data(using:.utf8)!
 let message2 = "Message 2".data(using:.utf8)!
 let message3 = "Message 3".data(using:.utf8)!
 
-let secretkey = sodium.secretStream.xchacha20poly1305.key()!
+let secretkey = sodium.secretStream.xchacha20poly1305.key()
 
 /* stream encryption */
 
@@ -80,7 +80,7 @@ A tag is attached to each message, and can be used to signal the end of a sub-se
 ```swift
 let sodium = Sodium()
 let message = "My Test Message".data(using:.utf8)!
-let secretKey = sodium.secretBox.key()!
+let secretKey = sodium.secretBox.key()
 let encrypted: Data = sodium.secretBox.seal(message: message, secretKey: secretKey)!
 if let decrypted = sodium.secretBox.open(nonceAndAuthenticatedCipherText: encrypted, secretKey: secretKey) {
     // authenticator is valid, decrypted contains the original message
@@ -276,7 +276,7 @@ Authentication tags are not signatures: the same key is used both for computing 
 ```swift
 let sodium = Sodium()
 let input = "test".data(using:.utf8)!
-let key = sodium.auth.key()!
+let key = sodium.auth.key()
 let tag = sodium.auth.tag(message: input, secretKey: key)!
 let tagIsValid = sodium.auth.verify(message: input, secretKey: key, tag: tag)
 ```
@@ -380,7 +380,7 @@ In order to generate a deterministic stream out of a seed, the `RandomBytes.dete
 ```swift
 let sodium = Sodium()
 let input = "test".data(using:.utf8)!
-let key = sodium.stream.key()!
+let key = sodium.stream.key()
 let (output, nonce) = sodium.stream.xor(input: input, secretKey: key)!
 let twice = sodium.stream.xor(input: output, nonce: nonce, secretKey: key)!
 

--- a/Sodium/Auth.swift
+++ b/Sodium/Auth.swift
@@ -12,7 +12,7 @@ public class Auth {
 
      - Returns: The generated key.
      */
-    public func key() -> SecretKey? {
+    public func key() -> SecretKey {
         var secretKey = Data(count: KeyBytes)
         secretKey.withUnsafeMutableBytes { secretKeyPtr in
             crypto_auth_keygen(secretKeyPtr)

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -17,7 +17,7 @@ public class GenericHash {
 
      - Returns: The generated key.
      */
-    public func key() -> Key? {
+    public func key() -> Key {
         var k = Data(count: KeyBytes)
         k.withUnsafeMutableBytes { kPtr in
             crypto_generichash_keygen(kPtr)

--- a/Sodium/KeyDerivation.swift
+++ b/Sodium/KeyDerivation.swift
@@ -15,7 +15,7 @@ public class KeyDerivation {
 
      - Returns: The generated key.
      */
-    public func key() -> Key? {
+    public func key() -> Key {
         var k = Data(count: KeyBytes)
         k.withUnsafeMutableBytes { kPtr in
             crypto_kdf_keygen(kPtr)

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -15,7 +15,7 @@ public class SecretBox {
 
      - Returns: The generated key.
      */
-    public func key() -> Key? {
+    public func key() -> Key {
         var k = Data(count: KeyBytes)
         k.withUnsafeMutableBytes { kPtr in
             crypto_secretbox_keygen(kPtr)

--- a/Sodium/SecretStream.swift
+++ b/Sodium/SecretStream.swift
@@ -22,7 +22,7 @@ public class SecretStream {
 
          - Returns: The generated key.
          */
-        public func key() -> Key? {
+        public func key() -> Key {
             var secretKey = Data(count: XChaCha20Poly1305.KeyBytes)
             secretKey.withUnsafeMutableBytes { secretKeyPtr in
                 crypto_secretstream_xchacha20poly1305_keygen(secretKeyPtr)

--- a/Sodium/ShortHash.swift
+++ b/Sodium/ShortHash.swift
@@ -12,7 +12,7 @@ public class ShortHash {
 
      - Returns: The generated key.
      */
-    public func key() -> Key? {
+    public func key() -> Key {
         var k = Data(count: KeyBytes)
         k.withUnsafeMutableBytes { kPtr in
             crypto_shorthash_keygen(kPtr)

--- a/Sodium/Stream.swift
+++ b/Sodium/Stream.swift
@@ -14,7 +14,7 @@ public class Stream {
 
      - Returns: The generated key.
      */
-    public func key() -> Key? {
+    public func key() -> Key {
         var k = Data(count: KeyBytes)
         k.withUnsafeMutableBytes { kPtr in
             crypto_stream_keygen(kPtr)

--- a/Tests/SodiumTests/ReadmeTests.swift
+++ b/Tests/SodiumTests/ReadmeTests.swift
@@ -104,7 +104,7 @@ class ReadmeTests : XCTestCase {
     func testSecretKeyAuthenticatedEncryption() {
         let sodium = Sodium()
         let message = "My Test Message".data(using:.utf8)!
-        let secretKey = sodium.secretBox.key()!
+        let secretKey = sodium.secretBox.key()
         let encrypted: Data = sodium.secretBox.seal(message: message, secretKey: secretKey)!
         if sodium.secretBox.open(nonceAndAuthenticatedCipherText: encrypted, secretKey: secretKey) != nil {
             // authenticator is valid, decrypted contains the original message
@@ -213,7 +213,7 @@ class ReadmeTests : XCTestCase {
     func testStream() {
         let sodium = Sodium()
         let input = "test".data(using:.utf8)!
-        let key = sodium.stream.key()!
+        let key = sodium.stream.key()
         let (output, nonce) = sodium.stream.xor(input: input, secretKey: key)!
         let twice = sodium.stream.xor(input: output, nonce: nonce, secretKey: key)!
 
@@ -223,7 +223,7 @@ class ReadmeTests : XCTestCase {
     func testAuth() {
         let sodium = Sodium()
         let input = "test".data(using:.utf8)!
-        let key = sodium.auth.key()!
+        let key = sodium.auth.key()
         let tag = sodium.auth.tag(message: input, secretKey: key)!
         let tagIsValid = sodium.auth.verify(message: input, secretKey: key, tag: tag)
 
@@ -232,7 +232,7 @@ class ReadmeTests : XCTestCase {
 
     func testKeyDerivation() {
         let sodium = Sodium()
-        let secretKey = sodium.keyDerivation.key()!
+        let secretKey = sodium.keyDerivation.key()
 
         let subKey1 = sodium.keyDerivation.derive(secretKey: secretKey,
                                                   index: 0, length: 32,
@@ -249,7 +249,7 @@ class ReadmeTests : XCTestCase {
         let message2 = "Message 2".data(using:.utf8)!
         let message3 = "Message 3".data(using:.utf8)!
 
-        let secretkey = sodium.secretStream.xchacha20poly1305.key()!
+        let secretkey = sodium.secretStream.xchacha20poly1305.key()
 
         /* stream encryption */
 

--- a/Tests/SodiumTests/SodiumTests.swift
+++ b/Tests/SodiumTests/SodiumTests.swift
@@ -93,7 +93,7 @@ class SodiumTests: XCTestCase {
 
     func testSecretBox() {
         let message = "My Test Message".toData()!
-        let secretKey = sodium.secretBox.key()!
+        let secretKey = sodium.secretBox.key()
 
         // test simple nonce + mac + message box
         let encrypted: Data = sodium.secretBox.seal(message: message, secretKey: secretKey)!
@@ -102,7 +102,7 @@ class SodiumTests: XCTestCase {
 
         XCTAssertNotEqual(sodium.secretBox.seal(message: message, secretKey: secretKey), encrypted, "Ciphertext of two encryption operations on the same plaintext shouldn't be equal. Make sure the nonce was used only once!")
 
-        XCTAssertNil(sodium.secretBox.open(nonceAndAuthenticatedCipherText: encrypted, secretKey: sodium.secretBox.key()!), "Shouldn't be able to decrypt with a bad key")
+        XCTAssertNil(sodium.secretBox.open(nonceAndAuthenticatedCipherText: encrypted, secretKey: sodium.secretBox.key()), "Shouldn't be able to decrypt with a bad key")
 
         // test (mac + message, nonce) box
         let (encrypted2, nonce2) = sodium.secretBox.seal(message: message, secretKey: secretKey)!
@@ -265,7 +265,7 @@ class SodiumTests: XCTestCase {
     }
 
     func testStream() {
-        let key = sodium.stream.key()!
+        let key = sodium.stream.key()
         let inputLen = Int(sodium.randomBytes.uniform(upperBound: 1024))
         let input = sodium.randomBytes.buf(length: inputLen)!
         let (output, nonce) = sodium.stream.xor(input: input, secretKey: key)!
@@ -281,7 +281,7 @@ class SodiumTests: XCTestCase {
         XCTAssertEqual(sodium.utils.bin2hex(tag)!, "b2a31b8d4e01afcab2ee545b5caf4e3d212a99d7b3a116a97cec8e83c32e107d")
         let verify = sodium.auth.verify(message: message, secretKey: key, tag: tag)
         XCTAssertTrue(verify)
-        let key2 = sodium.auth.key()!
+        let key2 = sodium.auth.key()
         let verify2 = sodium.auth.verify(message: message, secretKey: key2, tag: tag)
         XCTAssertFalse(verify2)
     }
@@ -298,22 +298,22 @@ class SodiumTests: XCTestCase {
     }
 
     func testKeyDerivationSubKeyTooShort() {
-        let secretKey = sodium.keyDerivation.key()!
+        let secretKey = sodium.keyDerivation.key()
         XCTAssertNil(sodium.keyDerivation.derive(secretKey: secretKey, index: 0, length: sodium.keyDerivation.BytesMin - 1, context: "TEST"))
     }
 
     func testKeyDerivationSubKeyTooLong() {
-        let secretKey = sodium.keyDerivation.key()!
+        let secretKey = sodium.keyDerivation.key()
         XCTAssertNil(sodium.keyDerivation.derive(secretKey: secretKey, index: 0, length: sodium.keyDerivation.BytesMax + 1, context: "TEST"))
     }
 
     func testKeyDerivationContextTooLong() {
-        let secretKey = sodium.keyDerivation.key()!
+        let secretKey = sodium.keyDerivation.key()
         XCTAssertNil(sodium.keyDerivation.derive(secretKey: secretKey, index: 0, length: sodium.keyDerivation.BytesMin, context: "TEST_SODIUM"))
     }
 
     func testKeyDerivation() {
-        let secretKey = sodium.keyDerivation.key()!
+        let secretKey = sodium.keyDerivation.key()
         let subKey1 = sodium.keyDerivation.derive(secretKey: secretKey, index: 0, length: sodium.keyDerivation.BytesMin, context: "TEST")!
         let subKey2 = sodium.keyDerivation.derive(secretKey: secretKey, index: 0, length: sodium.keyDerivation.BytesMin, context: "TEST")!
         let subKey3 = sodium.keyDerivation.derive(secretKey: secretKey, index: 0, length: sodium.keyDerivation.BytesMin, context: "TEST\0")!
@@ -337,7 +337,7 @@ class SodiumTests: XCTestCase {
     }
 
     func testSecretStream() {
-        let secretKey = sodium.secretStream.xchacha20poly1305.key()!
+        let secretKey = sodium.secretStream.xchacha20poly1305.key()
         XCTAssertEqual(secretKey.count, 32)
 
         let stream = sodium.secretStream.xchacha20poly1305.initPush(secretKey: secretKey)!


### PR DESCRIPTION
Returning a non-optional value saves the client code from unnecessary
error checking or generous use of force-unwraps.

This is a revised version of #125 which got reverted in #129 due to the
README not being updated.