### PR TITLE
Use constant local variables in-place of computed property of mutable value

### DIFF
--- a/Sodium/Aead.swift
+++ b/Sodium/Aead.swift
@@ -32,9 +32,10 @@ public struct Aead {
          - Returns: The generated nonce.
          */
         public func nonce() -> Nonce {
-            var nonce = Data(count: NonceBytes)
+            let nonceLen = NonceBytes
+            var nonce = Data(count: nonceLen)
             nonce.withUnsafeMutableBytes { noncePtr in
-                randombytes_buf(noncePtr, nonce.count)
+                randombytes_buf(noncePtr, nonceLen)
             }
             return nonce
         }

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -79,9 +79,10 @@ public class Box {
      - Returns: A nonce.
      */
     public func nonce() -> Nonce {
-        var nonce = Data(count: NonceBytes)
+        let nonceLen = NonceBytes
+        var nonce = Data(count: nonceLen)
         nonce.withUnsafeMutableBytes { noncePtr in
-            randombytes_buf(noncePtr, nonce.count)
+            randombytes_buf(noncePtr, nonceLen)
         }
         return nonce
     }

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -55,7 +55,7 @@ public class GenericHash {
                 message.withUnsafeBytes { messagePtr in
                     key.withUnsafeBytes { keyPtr in
                         crypto_generichash(
-                            outputPtr, output.count,
+                            outputPtr, outputLength,
                             messagePtr, CUnsignedLongLong(message.count),
                             keyPtr, key.count)
                     }
@@ -65,7 +65,7 @@ public class GenericHash {
             result = output.withUnsafeMutableBytes { outputPtr in
                 message.withUnsafeBytes { messagePtr in
                     crypto_generichash(
-                        outputPtr, output.count,
+                        outputPtr, outputLength,
                         messagePtr, CUnsignedLongLong(message.count),
                         nil, 0)
                 }
@@ -180,9 +180,10 @@ public class GenericHash {
          - Returns: The computed fingerprint.
          */
         public func final() -> Data? {
-            var output = Data(count: outputLength)
+            let outputLen = outputLength
+            var output = Data(count: outputLen)
             let result = output.withUnsafeMutableBytes { outputPtr in
-                crypto_generichash_final(state!, outputPtr, output.count)
+                crypto_generichash_final(state!, outputPtr, outputLen)
             }
             if result != 0 {
                 return nil

--- a/Sodium/RandomBytes.swift
+++ b/Sodium/RandomBytes.swift
@@ -17,7 +17,7 @@ public class RandomBytes {
         }
         var output = Data(count: length)
         output.withUnsafeMutableBytes { outputPtr in
-            randombytes_buf(outputPtr, output.count)
+            randombytes_buf(outputPtr, length)
         }
         return output
     }
@@ -55,7 +55,7 @@ public class RandomBytes {
         var output = Data(count: length)
         output.withUnsafeMutableBytes { outputPtr in
             seed.withUnsafeBytes { seedPtr in
-                randombytes_buf_deterministic(outputPtr, output.count, seedPtr)
+                randombytes_buf_deterministic(outputPtr, length, seedPtr)
             }
         }
         return output

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -29,9 +29,10 @@ public class SecretBox {
      - Returns: The generated nonce.
      */
     public func nonce() -> Nonce {
-        var nonce = Data(count: NonceBytes)
+        let nonceLen = NonceBytes
+        var nonce = Data(count: nonceLen)
         nonce.withUnsafeMutableBytes { noncePtr in
-            randombytes_buf(noncePtr, nonce.count)
+            randombytes_buf(noncePtr, nonceLen)
         }
         return nonce
     }

--- a/Sodium/Stream.swift
+++ b/Sodium/Stream.swift
@@ -28,9 +28,10 @@ public class Stream {
      - Returns: The generated nonce.
      */
     public func nonce() -> Nonce {
-        var nonce = Data(count: NonceBytes)
+        let nonceLen = NonceBytes
+        var nonce = Data(count: nonceLen)
         nonce.withUnsafeMutableBytes { noncePtr in
-            randombytes_buf(noncePtr, nonce.count)
+            randombytes_buf(noncePtr, nonceLen)
         }
         return nonce
     }

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -63,11 +63,12 @@ public class Utils {
      - Returns: The encoded hexdecimal string.
      */
     public func bin2hex(_ bin: Data) -> String? {
-        var hexData = Data(count: bin.count * 2 + 1)
+        let hexDataLen = bin.count * 2 + 1
+        var hexData = Data(count: hexDataLen)
 
         return hexData.withUnsafeMutableBytes { (hexPtr: UnsafeMutablePointer<Int8>) -> String? in
             bin.withUnsafeBytes { (binPtr: UnsafePointer<UInt8>) -> String? in
-                if sodium_bin2hex(hexPtr, hexData.count, binPtr, bin.count) == nil {
+                if sodium_bin2hex(hexPtr, hexDataLen, binPtr, bin.count) == nil {
                     return nil
                 }
                 return String.init(validatingUTF8: hexPtr)
@@ -125,11 +126,12 @@ public class Utils {
      - Returns: The encoded base64 string.
      */
     public func bin2base64(_ bin: Data, variant: Base64Variant = .URLSAFE) -> String? {
-        var b64Data = Data(count: sodium_base64_encoded_len(bin.count, variant.rawValue))
+        let b64DataLen = sodium_base64_encoded_len(bin.count, variant.rawValue)
+        var b64Data = Data(count: b64DataLen)
 
         return b64Data.withUnsafeMutableBytes { (b64Ptr: UnsafeMutablePointer<Int8>) -> String? in
             bin.withUnsafeBytes { (binPtr: UnsafePointer<UInt8>) -> String? in
-                if sodium_bin2base64(b64Ptr, b64Data.count, binPtr, bin.count, variant.rawValue) == nil {
+                if sodium_bin2base64(b64Ptr, b64DataLen, binPtr, bin.count, variant.rawValue) == nil {
                     return nil
                 }
                 return String.init(validatingUTF8: b64Ptr)
@@ -201,8 +203,9 @@ public class Utils {
      */
     public func unpad(data: inout Data, blockSize: Int) -> ()? {
         var unpaddedLen: size_t = 0
+        let dataLen = data.count
         let result = data.withUnsafeMutableBytes { dataPtr in
-            sodium_unpad(&unpaddedLen, dataPtr, data.count, blockSize)
+            sodium_unpad(&unpaddedLen, dataPtr, dataLen, blockSize)
         }
         if result != 0 {
             return nil


### PR DESCRIPTION
Swift 4.1 introduces warnings when mutable variables are accessed in a way where they may be modified and are simultaneously read. e.g. when using `noncePtr` and `nonce.count` here:

https://github.com/jedisct1/swift-sodium/blob/8df5a4a75a3b6088351362b5b6f2c2a93071b26f/Sodium/Aead.swift#L37

I've added local length constants where the length of a `Data` value was calculated from an instance variable in an attempt to make it harder to mismatch the init length with this stored constant. I've also added local length constants the length was calculated in-place for the same reason. Where a local variable or constant was available I've used it.

There are additional warnings present in Swift 4.1 due to [SE-0184](https://github.com/apple/swift-evolution/blob/master/proposals/0184-unsafe-pointers-add-missing.md) on lines like:

https://github.com/jedisct1/swift-sodium/blob/8df5a4a75a3b6088351362b5b6f2c2a93071b26f/Sodium/SecretStream.swift#L135

I believe that the fix is to change this line to `rawState.deallocate()` (might require writing an extension to `UnsafeMutableRawPointer` to invoke the old behaviour pre Swift 4.1 if the no argument overload wasn't backported). I think this change invokes the intention of the existing code, however, *I'm by no means certain*, so I wanted to highlight the change in-case I am incorrect. In-particular from SE-0184 (which is certainly worth a read):

> This method is extremely problematic because nearly all users, on first seeing the signature of `deallocate(capacity:)`, will naturally conclude from the `capacity` label that `deallocate(capacity:)` is equivalent to some kind of `realloc()` that can only shrink the buffer. However this is not the actual behavior — `deallocate(capacity:)` actually *ignores* the `capacity` argument and just calls `free()` on `self`. The current API is not only awkward and suboptimal, it is *misleading*. You can write perfectly legal Swift code that shouldn’t segfault, but still can[...]