### PR TITLE
Use guards where intention is to return

### DIFF
--- a/Sodium/Auth.swift
+++ b/Sodium/Auth.swift
@@ -29,7 +29,7 @@ public class Auth {
      - Returns: The computed authentication tag.
      */
     public func tag(message: Data, secretKey: SecretKey) -> Data? {
-        if secretKey.count != KeyBytes {
+        guard secretKey.count == KeyBytes else {
             return nil
         }
 
@@ -43,7 +43,7 @@ public class Auth {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return tag
@@ -59,7 +59,7 @@ public class Auth {
      - Returns: `true` if the verification is successful.
      */
     public func verify(message: Data, secretKey: SecretKey, tag: Data) -> Bool {
-        if secretKey.count != KeyBytes {
+        guard secretKey.count == KeyBytes else {
             return false
         }
         return tag.withUnsafeBytes { tagPtr in

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -41,7 +41,7 @@ public class Box {
                 crypto_box_keypair(pkPtr, skPtr)
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return KeyPair(publicKey: pk, secretKey: sk)
@@ -67,7 +67,7 @@ public class Box {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return KeyPair(publicKey: pk, secretKey: sk)
@@ -136,7 +136,7 @@ public class Box {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return authenticatedCipherText
@@ -152,9 +152,10 @@ public class Box {
      - Returns: The authenticated ciphertext and encryption nonce.
      */
     public func seal(message: Data, recipientPublicKey: PublicKey, senderSecretKey: SecretKey) -> (authenticatedCipherText: Data, nonce: Nonce)? {
-        if recipientPublicKey.count != PublicKeyBytes || senderSecretKey.count != SecretKeyBytes {
-            return nil
-        }
+        guard recipientPublicKey.count == PublicKeyBytes,
+              senderSecretKey.count == SecretKeyBytes
+        else { return nil }
+
         var authenticatedCipherText = Data(count: message.count + MacBytes)
         let nonce = self.nonce()
 
@@ -173,7 +174,7 @@ public class Box {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
@@ -189,9 +190,10 @@ public class Box {
      - Returns: The authenticated ciphertext, encryption nonce, and authentication tag.
      */
     public func seal(message: Data, recipientPublicKey: PublicKey, senderSecretKey: SecretKey) -> (authenticatedCipherText: Data, nonce: Nonce, mac: MAC)? {
-        if recipientPublicKey.count != PublicKeyBytes || senderSecretKey.count != SecretKeyBytes {
-            return nil
-        }
+        guard recipientPublicKey.count == PublicKeyBytes,
+              senderSecretKey.count == SecretKeyBytes
+        else { return nil }
+
         var authenticatedCipherText = Data(count: message.count)
         var mac = Data(count: MacBytes)
         let nonce = self.nonce()
@@ -212,7 +214,7 @@ public class Box {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return (authenticatedCipherText: authenticatedCipherText, nonce: nonce as Nonce, mac: mac as MAC)
@@ -228,7 +230,7 @@ public class Box {
      - Returns: The decrypted message.
      */
     public func open(nonceAndAuthenticatedCipherText: Data, senderPublicKey: PublicKey, recipientSecretKey: SecretKey) -> Data? {
-        if nonceAndAuthenticatedCipherText.count < NonceBytes + MacBytes {
+        guard nonceAndAuthenticatedCipherText.count >= NonceBytes + MacBytes else {
             return nil
         }
         let nonce = nonceAndAuthenticatedCipherText.subdata(in: 0..<NonceBytes) as Nonce
@@ -248,12 +250,12 @@ public class Box {
      - Returns: The decrypted message.
      */
     public func open(authenticatedCipherText: Data, senderPublicKey: PublicKey, recipientSecretKey: SecretKey, nonce: Nonce) -> Data? {
-        if nonce.count != NonceBytes || authenticatedCipherText.count < MacBytes {
-            return nil
-        }
-        if senderPublicKey.count != PublicKeyBytes || recipientSecretKey.count != SecretKeyBytes {
-            return nil
-        }
+        guard nonce.count == NonceBytes,
+              authenticatedCipherText.count >= MacBytes,
+              senderPublicKey.count == PublicKeyBytes,
+              recipientSecretKey.count == SecretKeyBytes
+        else { return nil }
+
         var message = Data(count: authenticatedCipherText.count - MacBytes)
         let result = message.withUnsafeMutableBytes { messagePtr in
             authenticatedCipherText.withUnsafeBytes { authenticatedCipherTextPtr in
@@ -270,7 +272,7 @@ public class Box {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return message
@@ -288,12 +290,12 @@ public class Box {
      - Returns: The decrypted message.
      */
     public func open(authenticatedCipherText: Data, senderPublicKey: PublicKey, recipientSecretKey: SecretKey, nonce: Nonce, mac: MAC) -> Data? {
-        if nonce.count != NonceBytes || mac.count != MacBytes {
-            return nil
-        }
-        if senderPublicKey.count != PublicKeyBytes || recipientSecretKey.count != SecretKeyBytes {
-            return nil
-        }
+        guard nonce.count == NonceBytes,
+              mac.count == MacBytes,
+              senderPublicKey.count == PublicKeyBytes,
+              recipientSecretKey.count == SecretKeyBytes
+        else { return nil }
+
         var message = Data(count: authenticatedCipherText.count)
 
         let result = message.withUnsafeMutableBytes { messagePtr in
@@ -313,7 +315,7 @@ public class Box {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return message
@@ -338,7 +340,7 @@ public class Box {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return key
@@ -353,7 +355,7 @@ public class Box {
      - Returns: The authenticated ciphertext and encryption nonce.
      */
     public func seal(message: Data, beforenm: Beforenm) -> (authenticatedCipherText: Data, nonce: Nonce)? {
-        if beforenm.count != BeforenmBytes {
+        guard beforenm.count == BeforenmBytes else {
             return nil
         }
         var authenticatedCipherText = Data(count: message.count + MacBytes)
@@ -373,7 +375,7 @@ public class Box {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
@@ -388,7 +390,7 @@ public class Box {
      - Returns: The decrypted message.
      */
     public func open(nonceAndAuthenticatedCipherText: Data, beforenm: Beforenm) -> Data? {
-        if nonceAndAuthenticatedCipherText.count < NonceBytes + MacBytes {
+        guard nonceAndAuthenticatedCipherText.count >= NonceBytes + MacBytes else {
             return nil
         }
         let nonce = nonceAndAuthenticatedCipherText.subdata(in: 0..<NonceBytes) as Nonce
@@ -407,12 +409,11 @@ public class Box {
      - Returns: The decrypted message.
      */
     public func open(authenticatedCipherText: Data, beforenm: Beforenm, nonce: Nonce) -> Data? {
-        if nonce.count != NonceBytes || authenticatedCipherText.count < MacBytes {
-            return nil
-        }
-        if beforenm.count != BeforenmBytes {
-            return nil
-        }
+        guard nonce.count == NonceBytes,
+              authenticatedCipherText.count >= MacBytes,
+              beforenm.count == BeforenmBytes
+        else { return nil }
+
         var message = Data(count: authenticatedCipherText.count - MacBytes)
         let result = message.withUnsafeMutableBytes { messagePtr in
             authenticatedCipherText.withUnsafeBytes { authenticatedCipherTextPtr in
@@ -426,7 +427,7 @@ public class Box {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return message
@@ -459,7 +460,7 @@ public class Box {
      - Returns: The anonymous ciphertext.
      */
     public func seal(message: Data, recipientPublicKey: Box.PublicKey) -> Data? {
-        if recipientPublicKey.count != PublicKeyBytes {
+        guard recipientPublicKey.count == PublicKeyBytes else {
             return nil
         }
         var anonymousCipherText = Data(count: SealBytes + message.count)
@@ -474,7 +475,7 @@ public class Box {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return anonymousCipherText
@@ -490,9 +491,11 @@ public class Box {
      - Returns: The decrypted message.
      */
     public func open(anonymousCipherText: Data, recipientPublicKey: PublicKey, recipientSecretKey: SecretKey) -> Data? {
-        if recipientPublicKey.count != PublicKeyBytes || recipientSecretKey.count != SecretKeyBytes || anonymousCipherText.count < SealBytes {
-            return nil
-        }
+        guard recipientPublicKey.count == PublicKeyBytes,
+              recipientSecretKey.count == SecretKeyBytes,
+              anonymousCipherText.count >= SealBytes
+        else { return nil }
+
         var message = Data(count: anonymousCipherText.count - SealBytes)
 
         let result = message.withUnsafeMutableBytes { messagePtr in
@@ -507,7 +510,7 @@ public class Box {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return message

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -71,7 +71,7 @@ public class GenericHash {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return output
@@ -185,7 +185,7 @@ public class GenericHash {
             let result = output.withUnsafeMutableBytes { outputPtr in
                 crypto_generichash_final(state!, outputPtr, outputLen)
             }
-            if result != 0 {
+            guard result == 0 else {
                 return nil
             }
             return output

--- a/Sodium/KeyDerivation.swift
+++ b/Sodium/KeyDerivation.swift
@@ -37,16 +37,12 @@ public class KeyDerivation {
      - Note: Output keys must have a length between BytesMin and BytesMax bytes (inclusive), otherwise an error is returned. Context must be at most 8 characters long. If the specified context is shorter than 8 characters, it will be padded to 8 characters. The master key is KeyBytes long.
      */
     public func derive(secretKey: Data, index: UInt64, length: Int, context: String) -> Data? {
-        if length < BytesMin || length > BytesMax {
-            return nil
-        }
-        if secretKey.count != KeyBytes {
-            return nil
-        }
-        var contextBin = context.data(using: String.Encoding.utf8)!
-        if contextBin.count > ContextBytes {
-            return nil
-        }
+        guard (BytesMin...BytesMax).contains(length),
+              secretKey.count == KeyBytes,
+              var contextBin = context.data(using: .utf8),
+              contextBin.count <= ContextBytes
+        else { return nil }
+
         while contextBin.count < ContextBytes {
             contextBin += [0]
         }
@@ -60,7 +56,7 @@ public class KeyDerivation {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return output

--- a/Sodium/KeyExchange.swift
+++ b/Sodium/KeyExchange.swift
@@ -63,7 +63,7 @@ public class KeyExchange {
      - Returns: A key pair containing the secret key and public key.
      */
     public func keyPair(seed: Data) -> KeyPair? {
-        if seed.count != SeedBytes {
+        guard seed.count == SeedBytes else {
             return nil
         }
         var pk = Data(count: PublicKeyBytes)
@@ -76,7 +76,7 @@ public class KeyExchange {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return KeyPair(publicKey: pk, secretKey: sk)
@@ -96,11 +96,10 @@ public class KeyExchange {
      - Note: `rx` on client side equals `tx` on server side and vice versa.
      */
     public func sessionKeyPair(publicKey: PublicKey, secretKey: SecretKey, otherPublicKey: PublicKey, side: Side) -> SessionKeyPair? {
-        if publicKey.count != PublicKeyBytes ||
-            secretKey.count != SecretKeyBytes ||
-            otherPublicKey.count != PublicKeyBytes {
-            return nil
-        }
+        guard publicKey.count == PublicKeyBytes,
+              secretKey.count == SecretKeyBytes,
+              otherPublicKey.count == PublicKeyBytes
+        else { return nil }
 
         var rx = Data(count: SessionKeyBytes)
         var tx = Data(count: SessionKeyBytes)
@@ -118,7 +117,7 @@ public class KeyExchange {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return SessionKeyPair(rx: rx, tx: tx)

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -42,7 +42,7 @@ public class PWHash {
                                   CUnsignedLongLong(opsLimit), size_t(memLimit))
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return String(data: output, encoding: .utf8)
@@ -102,7 +102,7 @@ public class PWHash {
      - Returns: The derived key data.
      */
     public func hash(outputLength: Int, passwd: Data, salt: Data, opsLimit: Int, memLimit: Int, alg: Alg = .Default) -> Data? {
-        if salt.count != SaltBytes {
+        guard salt.count == SaltBytes else {
             return nil
         }
         var output = Data(count: outputLength)
@@ -126,7 +126,7 @@ public class PWHash {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return output

--- a/Sodium/RandomBytes.swift
+++ b/Sodium/RandomBytes.swift
@@ -12,7 +12,7 @@ public class RandomBytes {
      - Returns: The generated data.
      */
     public func buf(length: Int) -> Data? {
-        if length < 0 {
+        guard length >= 0 else {
             return nil
         }
         var output = Data(count: length)
@@ -49,9 +49,11 @@ public class RandomBytes {
      - Returns: The generated data.
      */
     public func deterministic(length: Int, seed: Data) -> Data? {
-        if length < 0 || seed.count != SeedBytes || Int64(length) > 0x4000000000 as Int64 {
-            return nil
-        }
+        guard length >= 0,
+              seed.count == SeedBytes,
+              Int64(length) <= 0x4000000000 as Int64
+        else { return nil }
+
         var output = Data(count: length)
         output.withUnsafeMutableBytes { outputPtr in
             seed.withUnsafeBytes { seedPtr in

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -64,7 +64,7 @@ public class SecretBox {
      - Returns: The authenticated ciphertext and encryption nonce.
      */
     public func seal(message: Data, secretKey: Key) -> (authenticatedCipherText: Data, nonce: Nonce)? {
-        if secretKey.count != KeyBytes {
+        guard secretKey.count == KeyBytes else {
             return nil
         }
         var authenticatedCipherText = Data(count: message.count + MacBytes)
@@ -82,7 +82,7 @@ public class SecretBox {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
@@ -97,7 +97,7 @@ public class SecretBox {
      - Returns: The encrypted ciphertext, encryption nonce, and authentication tag.
      */
     public func seal(message: Data, secretKey: Key) -> (cipherText: Data, nonce: Nonce, mac: MAC)? {
-        if secretKey.count != KeyBytes {
+        guard secretKey.count == KeyBytes else {
             return nil
         }
         var cipherText = Data(count: message.count)
@@ -118,7 +118,7 @@ public class SecretBox {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return (cipherText: cipherText, nonce: nonce, mac: mac)
@@ -133,7 +133,7 @@ public class SecretBox {
      - Returns: The decrypted message.
      */
     public func open(nonceAndAuthenticatedCipherText: Data, secretKey: Key) -> Data? {
-        if nonceAndAuthenticatedCipherText.count < MacBytes + NonceBytes {
+        guard nonceAndAuthenticatedCipherText.count >= MacBytes + NonceBytes else {
             return nil
         }
         let nonce = nonceAndAuthenticatedCipherText.subdata(in: 0..<NonceBytes) as Nonce
@@ -152,7 +152,7 @@ public class SecretBox {
      - Returns: The decrypted message.
      */
     public func open(authenticatedCipherText: Data, secretKey: Key, nonce: Nonce) -> Data? {
-        if authenticatedCipherText.count < MacBytes {
+        guard authenticatedCipherText.count >= MacBytes else {
             return nil
         }
         var message = Data(count: authenticatedCipherText.count - MacBytes)
@@ -169,7 +169,7 @@ public class SecretBox {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return message
@@ -185,12 +185,11 @@ public class SecretBox {
      - Returns: The decrypted message.
      */
     public func open(cipherText: Data, secretKey: Key, nonce: Nonce, mac: MAC) -> Data? {
-        if nonce.count != NonceBytes || mac.count != MacBytes {
-            return nil
-        }
-        if secretKey.count != KeyBytes {
-            return nil
-        }
+        guard nonce.count == NonceBytes,
+              mac.count == MacBytes,
+              secretKey.count == KeyBytes
+        else { return nil }
+
         var message = Data(count: cipherText.count)
 
         let result = message.withUnsafeMutableBytes { messagePtr in
@@ -207,7 +206,7 @@ public class SecretBox {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return message

--- a/Sodium/SecretStream.swift
+++ b/Sodium/SecretStream.swift
@@ -65,7 +65,7 @@ public class SecretStream {
             private var _header: Header
 
             init?(secretKey: Key) {
-                if secretKey.count != KeyBytes {
+                guard secretKey.count == KeyBytes else {
                     return nil
                 }
                 let rawState = UnsafeMutablePointer<UInt8>.allocate(capacity: crypto_secretstream_xchacha20poly1305_statebytes())
@@ -79,7 +79,7 @@ public class SecretStream {
                         crypto_secretstream_xchacha20poly1305_init_push(state, headerPtr, secretKeyPtr)
                     }
                 }
-                if result != 0 {
+                guard result == 0 else {
                     free()
                     return nil
                 }
@@ -114,7 +114,7 @@ public class SecretStream {
                         }
                     }
                 }
-                if result != 0 {
+                guard result == 0 else {
                     return nil
                 }
                 return cipherText
@@ -145,7 +145,7 @@ public class SecretStream {
             private var state: UnsafeMutablePointer<crypto_secretstream_xchacha20poly1305_state>?
 
             init?(secretKey: Key, header: Header) {
-                if header.count != HeaderBytes || secretKey.count != KeyBytes {
+                guard header.count == HeaderBytes, secretKey.count == KeyBytes else {
                     return nil
                 }
                 let rawState = UnsafeMutablePointer<UInt8>.allocate(capacity: crypto_secretstream_xchacha20poly1305_statebytes())
@@ -158,7 +158,7 @@ public class SecretStream {
                         crypto_secretstream_xchacha20poly1305_init_pull(state, headerPtr, secretKeyPtr)
                     }
                 }
-                if result != 0 {
+                guard result == 0 else {
                     free()
                     return nil
                 }
@@ -173,7 +173,7 @@ public class SecretStream {
              - Returns: The decrypted message, as well as the tag attached to it.
              */
             public func pull(cipherText: Data, ad: Data? = nil) -> (Data, Tag)? {
-                if cipherText.count < ABytes {
+                guard cipherText.count >= ABytes else {
                     return nil
                 }
                 var message = Data(count: cipherText.count - ABytes)
@@ -186,10 +186,7 @@ public class SecretStream {
                         }
                     }
                 }
-                if result != 0 {
-                    return nil
-                }
-                guard let tag = Tag.init(rawValue: _tag) else {
+                guard result == 0, let tag = Tag.init(rawValue: _tag) else {
                     return nil
                 }
                 return (message, tag)

--- a/Sodium/ShortHash.swift
+++ b/Sodium/ShortHash.swift
@@ -29,7 +29,7 @@ public class ShortHash {
      - Returns: The computed fingerprint.
      */
     public func hash(message: Data, key: Data) -> Data? {
-        if key.count != KeyBytes {
+        guard key.count == KeyBytes else {
             return nil
         }
         var output = Data(count: Bytes)
@@ -41,7 +41,7 @@ public class ShortHash {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return output

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -35,7 +35,7 @@ public class Sign {
                 crypto_sign_keypair(pkPtr, skPtr)
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return KeyPair(publicKey: pk, secretKey: sk)
@@ -49,7 +49,7 @@ public class Sign {
      - Returns: A key pair containing the secret key and public key.
      */
     public func keyPair(seed: Data) -> KeyPair? {
-        if seed.count != SeedBytes {
+        guard seed.count == SeedBytes else {
             return nil
         }
         var pk = Data(count: PublicKeyBytes)
@@ -62,7 +62,7 @@ public class Sign {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return KeyPair(publicKey: pk, secretKey: sk)
@@ -77,7 +77,7 @@ public class Sign {
      - Returns: The signed message.
      */
     public func sign(message: Data, secretKey: SecretKey) -> Data? {
-        if secretKey.count != SecretKeyBytes {
+        guard secretKey.count == SecretKeyBytes else {
             return nil
         }
         var signedMessage = Data(count: message.count + Bytes)
@@ -92,7 +92,7 @@ public class Sign {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return signedMessage
@@ -107,7 +107,7 @@ public class Sign {
      - Returns: The computed signature.
      */
     public func signature(message: Data, secretKey: SecretKey) -> Data? {
-        if secretKey.count != SecretKeyBytes {
+        guard secretKey.count == SecretKeyBytes else {
             return nil
         }
         var signature = Data(count: Bytes)
@@ -123,7 +123,7 @@ public class Sign {
             }
         }
 
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
 
@@ -155,7 +155,7 @@ public class Sign {
      - Returns: `true` if verification is successful.
      */
     public func verify(message: Data, publicKey: PublicKey, signature: Data) -> Bool {
-        if publicKey.count != PublicKeyBytes {
+        guard publicKey.count == PublicKeyBytes else {
             return false
         }
 
@@ -179,7 +179,7 @@ public class Sign {
      - Returns: The message data if verification is successful.
      */
     public func open(signedMessage: Data, publicKey: PublicKey) -> Data? {
-        if publicKey.count != PublicKeyBytes || signedMessage.count < Bytes {
+        guard publicKey.count == PublicKeyBytes, signedMessage.count >= Bytes else {
             return nil
         }
         var message = Data(count: signedMessage.count - Bytes)
@@ -195,7 +195,7 @@ public class Sign {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return message

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -18,7 +18,7 @@ public class Sodium {
     public let aead = Aead()
 
     private static let once: Void = {
-        if sodium_init() < 0 {
+        guard sodium_init() >= 0 else {
             fatalError("Failed to initialize libsodium")
         }
     }()

--- a/Sodium/Stream.swift
+++ b/Sodium/Stream.swift
@@ -50,7 +50,7 @@ public class Stream {
      -  Returns: input XOR keystream(secretKey, nonce)
      */
     public func xor(input: Data, nonce: Nonce, secretKey: Key) -> Data? {
-        if secretKey.count != KeyBytes || nonce.count != NonceBytes {
+        guard secretKey.count == KeyBytes, nonce.count == NonceBytes else {
             return nil
         }
         var output = Data(count: input.count)
@@ -63,7 +63,7 @@ public class Stream {
                 }
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         return output

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -25,7 +25,7 @@ public class Utils {
      - Returns: `true` if the bytes in `b1` match the bytes in `b2`. Otherwise, it returns false.
      */
     public func equals(_ b1: Data, _ b2: Data) -> Bool {
-        if b1.count != b2.count {
+        guard b1.count == b2.count else {
             return false
         }
         return b1.withUnsafeBytes { b1Ptr in
@@ -44,7 +44,7 @@ public class Utils {
      `1`  if `b1` is less than `b2` (considered as little-endian values)
      */
     public func compare(_ b1: Data, _ b2: Data) -> Int? {
-        if b1.count != b2.count {
+        guard b1.count == b2.count else {
             return nil
         }
         return b1.withUnsafeBytes { b1Ptr in
@@ -68,7 +68,7 @@ public class Utils {
 
         return hexData.withUnsafeMutableBytes { (hexPtr: UnsafeMutablePointer<Int8>) -> String? in
             bin.withUnsafeBytes { (binPtr: UnsafePointer<UInt8>) -> String? in
-                if sodium_bin2hex(hexPtr, hexDataLen, binPtr, bin.count) == nil {
+                guard nil != sodium_bin2hex(hexPtr, hexDataLen, binPtr, bin.count) else {
                     return nil
                 }
                 return String.init(validatingUTF8: hexPtr)
@@ -102,7 +102,7 @@ public class Utils {
                                ignore_cstr, &binDataLen, nil)
             }
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         binData.count = Int(binDataLen)
@@ -131,7 +131,7 @@ public class Utils {
 
         return b64Data.withUnsafeMutableBytes { (b64Ptr: UnsafeMutablePointer<Int8>) -> String? in
             bin.withUnsafeBytes { (binPtr: UnsafePointer<UInt8>) -> String? in
-                if sodium_bin2base64(b64Ptr, b64DataLen, binPtr, bin.count, variant.rawValue) == nil {
+                guard nil != sodium_bin2base64(b64Ptr, b64DataLen, binPtr, bin.count, variant.rawValue) else {
                     return nil
                 }
                 return String.init(validatingUTF8: b64Ptr)
@@ -165,7 +165,7 @@ public class Utils {
                                   ignore_cstr, &binDataLen, nil, variant.rawValue)
             }
         }
-        if  result != 0 {
+        guard result == 0 else {
             return nil
         }
         binData.count = Int(binDataLen)
@@ -187,7 +187,7 @@ public class Utils {
         let result = data.withUnsafeMutableBytes { dataPtr in
             sodium_pad(&paddedLen, dataPtr, dataCount, blockSize, dataCount + blockSize)
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         data.count = Int(paddedLen)
@@ -207,7 +207,7 @@ public class Utils {
         let result = data.withUnsafeMutableBytes { dataPtr in
             sodium_unpad(&unpaddedLen, dataPtr, dataLen, blockSize)
         }
-        if result != 0 {
+        guard result == 0 else {
             return nil
         }
         data.count = Int(unpaddedLen)

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -68,7 +68,7 @@ public class Utils {
 
         return hexData.withUnsafeMutableBytes { (hexPtr: UnsafeMutablePointer<Int8>) -> String? in
             bin.withUnsafeBytes { (binPtr: UnsafePointer<UInt8>) -> String? in
-                guard nil != sodium_bin2hex(hexPtr, hexDataLen, binPtr, bin.count) else {
+                guard sodium_bin2hex(hexPtr, hexDataLen, binPtr, bin.count) != nil else {
                     return nil
                 }
                 return String.init(validatingUTF8: hexPtr)
@@ -131,7 +131,7 @@ public class Utils {
 
         return b64Data.withUnsafeMutableBytes { (b64Ptr: UnsafeMutablePointer<Int8>) -> String? in
             bin.withUnsafeBytes { (binPtr: UnsafePointer<UInt8>) -> String? in
-                guard nil != sodium_bin2base64(b64Ptr, b64DataLen, binPtr, bin.count, variant.rawValue) else {
+                guard sodium_bin2base64(b64Ptr, b64DataLen, binPtr, bin.count, variant.rawValue) != nil else {
                     return nil
                 }
                 return String.init(validatingUTF8: b64Ptr)


### PR DESCRIPTION
Guard statements come with the added compiler check that the body of the `else { ... }` statement returns to the parent scope or otherwise does not permit falling through (e.g. via a return, throwing, calling a function with return type `Never` etc...) which makes them perfect for asserting a condition is true for the remainder of the function body.

IMO they also tend to just "work better in practice", for example in `KeyDerivation.swift`:

```diff
-        if length < BytesMin || length > BytesMax {
-            return nil
-        }
-        if secretKey.count != KeyBytes {
-            return nil
-        }
-        var contextBin = context.data(using: String.Encoding.utf8)!
-        if contextBin.count > ContextBytes {
-            return nil
-        }
+        guard (BytesMin...BytesMax).contains(length),
+              secretKey.count == KeyBytes,
+              var contextBin = context.data(using: .utf8),
+              contextBin.count <= ContextBytes
+        else { return nil }
+
```

`length` being bound between a min and a max is much more succinctly expressed as the true statement than the false one. We're also able to remove the use of a forced unwrap by taking advantage of the conditional unwrapping assignment mechanics within the `guard`. Finally, since a `guard` lends itself very well to writing sequential statements I believe these three `if ... { return nil }` checks can be merged into a single `guard` statement spanning multiple lines without loss to readability.

As a matter of personal preference I find it easier to read a set of conditions which all must be true in bulk than a or chain of negative statements for which the intent is that the opposite is true for all of them for the remainder of the function. Of course you may disagree – this PR merely a suggestion :)