### PR TITLE
State stream protocol

### DIFF
--- a/Sodium.xcodeproj/project.pbxproj
+++ b/Sodium.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		CFD847281BA8120900B1260F /* PWHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097F20D91AF127480088C2FE /* PWHash.swift */; };
 		D2A274061F13AD9300958702 /* KeyDerivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A274051F13AD9300958702 /* KeyDerivation.swift */; };
 		D85101041E22EF5B003DB2E8 /* ReadmeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85101031E22EF5B003DB2E8 /* ReadmeTests.swift */; };
+		DD1E4D06208E744100BE7A3F /* StateStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1E4D05208E744100BE7A3F /* StateStream.swift */; };
+		DD1E4D07208E744100BE7A3F /* StateStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1E4D05208E744100BE7A3F /* StateStream.swift */; };
 		F87EEC402063C655006C830D /* Aead.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87EEC3F2063C655006C830D /* Aead.swift */; };
 /* End PBXBuildFile section */
 
@@ -192,6 +194,7 @@
 		D2A274051F13AD9300958702 /* KeyDerivation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyDerivation.swift; sourceTree = "<group>"; };
 		D85101031E22EF5B003DB2E8 /* ReadmeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadmeTests.swift; sourceTree = "<group>"; };
 		D85101051E22F77E003DB2E8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		DD1E4D05208E744100BE7A3F /* StateStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateStream.swift; sourceTree = "<group>"; };
 		F87EEC3F2063C655006C830D /* Aead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Aead.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -271,6 +274,7 @@
 				09A943E91A4EB70900C8A04F /* libsodium */,
 				09A943CC1A4EB5F500C8A04F /* Sodium.h */,
 				094F21E91A5017CA001C3141 /* Box.swift */,
+				DD1E4D05208E744100BE7A3F /* StateStream.swift */,
 				038365141A5A51D20081136D /* SecretBox.swift */,
 				0942982F1EDDAA3B001236B1 /* Stream.swift */,
 				095D80561A4ED0B4000B83F9 /* GenericHash.swift */,
@@ -670,6 +674,7 @@
 				095D805D1A4F4F72000B83F9 /* Utils.swift in Sources */,
 				091C7CDC1A50839D002E5351 /* Sign.swift in Sources */,
 				A0918C781E92489100C1DC33 /* Auth.swift in Sources */,
+				DD1E4D06208E744100BE7A3F /* StateStream.swift in Sources */,
 				094298301EDDAA3B001236B1 /* Stream.swift in Sources */,
 				D2A274061F13AD9300958702 /* KeyDerivation.swift in Sources */,
 				09A5AC121F74466700D3200B /* SecretStream.swift in Sources */,
@@ -721,6 +726,7 @@
 				90C75EE91AE3583E00F1E749 /* RandomBytes.swift in Sources */,
 				60C211E71EB73D3900882AD0 /* Auth.swift in Sources */,
 				094298311EDDAA3B001236B1 /* Stream.swift in Sources */,
+				DD1E4D07208E744100BE7A3F /* StateStream.swift in Sources */,
 				6096E7321F194FA800E6599F /* KeyDerivation.swift in Sources */,
 				098DAF041F76E35C00DFB1C3 /* SecretStream.swift in Sources */,
 				90C75EEA1AE3583E00F1E749 /* ShortHash.swift in Sources */,

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -131,7 +131,7 @@ public class GenericHash {
         public var outputLength: Int = 0
 
         init?(key: Data?, outputLength: Int) {
-            state = Stream.gen(capacity: capacity)
+            state = Stream.generate()
             var result: Int32 = -1
             if let key = key {
                 result = key.withUnsafeBytes { keyPtr in

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -125,7 +125,7 @@ public class GenericHash {
 
     public class Stream: StateStream {
         typealias State = crypto_generichash_state
-        var capacity = crypto_generichash_statebytes()
+        static var capacity = crypto_generichash_statebytes()
         var state: UnsafeMutablePointer<State>
 
         public var outputLength: Int = 0

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -126,7 +126,7 @@ public class GenericHash {
     public class Stream: StateStream {
         typealias State = crypto_generichash_state
         static var capacity = crypto_generichash_statebytes()
-        var state: UnsafeMutablePointer<State>
+        private var state: UnsafeMutablePointer<State>
 
         public var outputLength: Int = 0
 
@@ -145,6 +145,10 @@ public class GenericHash {
                 return nil
             }
             self.outputLength = outputLength
+        }
+
+        private func free() {
+            Stream.free(state)
         }
 
         deinit {

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -125,7 +125,7 @@ public class GenericHash {
 
     public class Stream: StateStream {
         typealias State = crypto_generichash_state
-        static var capacity = crypto_generichash_statebytes()
+        static let capacity = crypto_generichash_statebytes()
         private var state: UnsafeMutablePointer<State>
 
         public var outputLength: Int = 0

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -123,16 +123,15 @@ public class GenericHash {
         return Stream(key: nil, outputLength: outputLength)
     }
 
-    public class Stream {
+    public class Stream: StateStream {
+        typealias State = crypto_generichash_state
+        var capacity = crypto_generichash_statebytes()
+        var state: UnsafeMutablePointer<State>
+
         public var outputLength: Int = 0
-        private var state: UnsafeMutablePointer<crypto_generichash_state>?
 
         init?(key: Data?, outputLength: Int) {
-            let rawState = UnsafeMutablePointer<UInt8>.allocate(capacity: crypto_generichash_statebytes())
-            state = UnsafeMutableRawPointer(rawState).bindMemory(to: crypto_generichash_state.self, capacity: 1)
-            guard let state = state else {
-                return nil
-            }
+            state = Stream.gen(capacity: capacity)
             var result: Int32 = -1
             if let key = key {
                 result = key.withUnsafeBytes { keyPtr in
@@ -141,20 +140,11 @@ public class GenericHash {
             } else {
                 result = crypto_generichash_init(state, nil, 0, outputLength)
             }
-            if result != 0 {
+            guard result == 0 else {
                 free()
                 return nil
             }
             self.outputLength = outputLength
-        }
-
-        private func free() {
-            guard let state = state else {
-                return
-            }
-            let rawState = UnsafeMutableRawPointer(state).bindMemory(to: UInt8.self, capacity: crypto_generichash_statebytes())
-            rawState.deallocate(capacity: 1)
-            self.state = nil
         }
 
         deinit {
@@ -170,7 +160,7 @@ public class GenericHash {
          */
         public func update(input: Data) -> Bool {
             return input.withUnsafeBytes { inputPtr in
-                crypto_generichash_update(state!, inputPtr, CUnsignedLongLong(input.count)) == 0
+                crypto_generichash_update(state, inputPtr, CUnsignedLongLong(input.count)) == 0
             }
         }
 
@@ -183,7 +173,7 @@ public class GenericHash {
             let outputLen = outputLength
             var output = Data(count: outputLen)
             let result = output.withUnsafeMutableBytes { outputPtr in
-                crypto_generichash_final(state!, outputPtr, outputLen)
+                crypto_generichash_final(state, outputPtr, outputLen)
             }
             guard result == 0 else {
                 return nil

--- a/Sodium/SecretStream.swift
+++ b/Sodium/SecretStream.swift
@@ -63,7 +63,7 @@ public class SecretStream {
         public class PushStream: StateStream {
             typealias State = crypto_secretstream_xchacha20poly1305_state
 
-            var capacity = crypto_secretstream_xchacha20poly1305_statebytes()
+            static var capacity = crypto_secretstream_xchacha20poly1305_statebytes()
             var state: UnsafeMutablePointer<State>
 
             private var _header: Header
@@ -135,7 +135,7 @@ public class SecretStream {
         public class PullStream: StateStream {
             typealias State = crypto_secretstream_xchacha20poly1305_state
 
-            var capacity = crypto_secretstream_xchacha20poly1305_statebytes()
+            static var capacity = crypto_secretstream_xchacha20poly1305_statebytes()
             var state: UnsafeMutablePointer<State>
 
             init?(secretKey: Key, header: Header) {

--- a/Sodium/SecretStream.swift
+++ b/Sodium/SecretStream.swift
@@ -72,7 +72,7 @@ public class SecretStream {
                 guard secretKey.count == KeyBytes else {
                     return nil
                 }
-                state = PushStream.gen(capacity: capacity)
+                state = PushStream.generate()
                 _header = Data(count: HeaderBytes)
                 let result = secretKey.withUnsafeBytes { secretKeyPtr in
                     _header.withUnsafeMutableBytes { headerPtr in
@@ -142,7 +142,7 @@ public class SecretStream {
                 guard header.count == HeaderBytes, secretKey.count == KeyBytes else {
                     return nil
                 }
-                state = PushStream.gen(capacity: capacity)
+                state = PushStream.generate()
                 let result = secretKey.withUnsafeBytes { secretKeyPtr in
                     header.withUnsafeBytes { headerPtr in
                         crypto_secretstream_xchacha20poly1305_init_pull(state, headerPtr, secretKeyPtr)

--- a/Sodium/SecretStream.swift
+++ b/Sodium/SecretStream.swift
@@ -63,7 +63,7 @@ public class SecretStream {
         public class PushStream: StateStream {
             typealias State = crypto_secretstream_xchacha20poly1305_state
 
-            static var capacity = crypto_secretstream_xchacha20poly1305_statebytes()
+            static let capacity = crypto_secretstream_xchacha20poly1305_statebytes()
             private var state: UnsafeMutablePointer<State>
 
             private var _header: Header
@@ -139,7 +139,7 @@ public class SecretStream {
         public class PullStream: StateStream {
             typealias State = crypto_secretstream_xchacha20poly1305_state
 
-            static var capacity = crypto_secretstream_xchacha20poly1305_statebytes()
+            static let capacity = crypto_secretstream_xchacha20poly1305_statebytes()
             private var state: UnsafeMutablePointer<State>
 
             init?(secretKey: Key, header: Header) {

--- a/Sodium/SecretStream.swift
+++ b/Sodium/SecretStream.swift
@@ -64,7 +64,7 @@ public class SecretStream {
             typealias State = crypto_secretstream_xchacha20poly1305_state
 
             static var capacity = crypto_secretstream_xchacha20poly1305_statebytes()
-            var state: UnsafeMutablePointer<State>
+            private var state: UnsafeMutablePointer<State>
 
             private var _header: Header
 
@@ -127,6 +127,10 @@ public class SecretStream {
                 crypto_secretstream_xchacha20poly1305_rekey(state)
             }
 
+            private func free() {
+                PushStream.free(state)
+            }
+
             deinit {
                 free()
             }
@@ -136,7 +140,7 @@ public class SecretStream {
             typealias State = crypto_secretstream_xchacha20poly1305_state
 
             static var capacity = crypto_secretstream_xchacha20poly1305_statebytes()
-            var state: UnsafeMutablePointer<State>
+            private var state: UnsafeMutablePointer<State>
 
             init?(secretKey: Key, header: Header) {
                 guard header.count == HeaderBytes, secretKey.count == KeyBytes else {
@@ -187,6 +191,10 @@ public class SecretStream {
              */
             public func rekey() {
                 crypto_secretstream_xchacha20poly1305_rekey(state)
+            }
+
+            private func free() {
+                PullStream.free(state)
             }
 
             deinit {

--- a/Sodium/StateStream.swift
+++ b/Sodium/StateStream.swift
@@ -2,14 +2,13 @@ protocol StateStream {
     associatedtype State
 
     static var capacity: Int { get }
-    var state: UnsafeMutablePointer<State> { get set }
 }
 
 extension StateStream {
-    func free() {
+    static func free(_ state: UnsafeMutablePointer<State>) {
         let rawState = UnsafeMutableRawPointer(state).bindMemory(
             to: UInt8.self,
-            capacity: Self.capacity
+            capacity: capacity
         )
 
         #if swift(>=4.1)

--- a/Sodium/StateStream.swift
+++ b/Sodium/StateStream.swift
@@ -19,8 +19,8 @@ extension StateStream {
         #endif
     }
 
-    static func gen(capacity bytes: Int) -> UnsafeMutablePointer<State> {
-        let rawState = UnsafeMutablePointer<UInt8>.allocate(capacity: bytes)
+    static func generate() -> UnsafeMutablePointer<State> {
+        let rawState = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
 
         return UnsafeMutableRawPointer(rawState).bindMemory(
             to: State.self,

--- a/Sodium/StateStream.swift
+++ b/Sodium/StateStream.swift
@@ -6,14 +6,12 @@ protocol StateStream {
 }
 
 extension StateStream {
-    var rawState: UnsafeMutablePointer<UInt8> {
-        return UnsafeMutableRawPointer(state).bindMemory(
+    func free() {
+        let rawState = UnsafeMutableRawPointer(state).bindMemory(
             to: UInt8.self,
             capacity: capacity
         )
-    }
 
-    func free() {
         #if swift(>=4.1)
         rawState.deallocate()
         #else

--- a/Sodium/StateStream.swift
+++ b/Sodium/StateStream.swift
@@ -1,0 +1,32 @@
+protocol StateStream {
+    associatedtype State
+
+    var capacity: Int { get }
+    var state: UnsafeMutablePointer<State> { get set }
+}
+
+extension StateStream {
+    var rawState: UnsafeMutablePointer<UInt8> {
+        return UnsafeMutableRawPointer(state).bindMemory(
+            to: UInt8.self,
+            capacity: capacity
+        )
+    }
+
+    func free() {
+        #if swift(>=4.1)
+        rawState.deallocate()
+        #else
+        rawState.deallocate(capacity: 1)
+        #endif
+    }
+
+    static func gen(capacity bytes: Int) -> UnsafeMutablePointer<State> {
+        let rawState = UnsafeMutablePointer<UInt8>.allocate(capacity: bytes)
+
+        return UnsafeMutableRawPointer(rawState).bindMemory(
+            to: State.self,
+            capacity: 1
+        )
+    }
+}

--- a/Sodium/StateStream.swift
+++ b/Sodium/StateStream.swift
@@ -1,7 +1,7 @@
 protocol StateStream {
     associatedtype State
 
-    var capacity: Int { get }
+    static var capacity: Int { get }
     var state: UnsafeMutablePointer<State> { get set }
 }
 
@@ -9,7 +9,7 @@ extension StateStream {
     func free() {
         let rawState = UnsafeMutableRawPointer(state).bindMemory(
             to: UInt8.self,
-            capacity: capacity
+            capacity: Self.capacity
         )
 
         #if swift(>=4.1)


### PR DESCRIPTION
There are a few classes (`GenericHash.Stream`, `SecretStream.XChaCha20Poly1305.PushStream`, and `SecretStream.XChaCha20Poly1305.PullStream`) which have some very similar internal behaviour which boils down to picking a types and specifying a value.

Using a new `StateStream` protocol we can allow these implementations to just specify this information and have `free()` and state generation be taken care of by a protocol extension.

I've also removed the optional wrapper around `state` since 1. the `.some` state was forced unwrapped in almost all of its use (either explicitly with `!` or implicitly via use of the C API); 2. all calls to `free()` were made right before the `StateStream` object was deinitialised or failed to initialise – either way – there would be no subsequent direct access to the pointer variable `state` because there would be no way to refer to the variable, 3. there appear to be no point during which normal function of these objects would permit the `nil` state (it was only set to this state before the object is thrown away). Thus it seemed that setting `state` to `nil` was both unnecessary and the `nil` state was not taken advantage of for preventing use of `nil` as a pointer (due to the forced unwraps).