### PR TITLE
Remove explicit pointer use from padding

### DIFF
--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -147,27 +147,21 @@ public class Utils {
      - Parameter data: input/output buffer, will be modified in-place
      - Parameter blocksize: the block size
      */
-    public func pad(data bytes: inout Bytes, blockSize: Int) -> ()? {
-        // we must use Data and not Bytes because we need to increase the
-        // count size before passing to `sodium_pad` without initilising bytes
-        var data = Data(bytes)
-        let dataCount = data.count
-        data.reserveCapacity(dataCount + blockSize)
-        data.count = dataCount + blockSize
+    public func pad(bytes: inout Bytes, blockSize: Int) -> ()? {
+        let bytesCount = bytes.count
+        bytes += Bytes(count: blockSize)
+
         var paddedLen: size_t = 0
-        guard .SUCCESS == data.withUnsafeMutableBytes({
-            dataPtr in sodium_pad(
-                &paddedLen,
-                dataPtr, dataCount,
-                blockSize,
-                dataCount + blockSize
-            ).exitCode
-        }) else { return nil }
 
-        data.count = paddedLen
+        guard .SUCCESS == sodium_pad(
+            &paddedLen,
+            &bytes, bytesCount,
+            blockSize,
+            bytesCount + blockSize
+        ).exitCode else { return nil }
 
-        // return the new bytes by argument
-        bytes = Bytes(data)
+        bytes = bytes[..<paddedLen].bytes
+
         return ()
     }
 

--- a/Tests/SodiumTests/ReadmeTests.swift
+++ b/Tests/SodiumTests/ReadmeTests.swift
@@ -293,7 +293,7 @@ class ReadmeTests : XCTestCase {
         var data = "test".bytes
 
         // make data.count a multiple of 16
-        sodium.utils.pad(data: &data, blockSize: 16)!
+        sodium.utils.pad(bytes: &data, blockSize: 16)!
 
         // restore original size
         sodium.utils.unpad(bytes: &data, blockSize: 16)!

--- a/Tests/SodiumTests/SodiumTests.swift
+++ b/Tests/SodiumTests/SodiumTests.swift
@@ -374,7 +374,7 @@ class SodiumTests: XCTestCase {
 
     func testPad() {
         var data = "test".bytes
-        sodium.utils.pad(data: &data, blockSize: 16)!
+        sodium.utils.pad(bytes: &data, blockSize: 16)!
         XCTAssertTrue(data.count % 16 == 0)
         sodium.utils.unpad(bytes: &data, blockSize: 16)!
         XCTAssertTrue(data.count == 4)


### PR DESCRIPTION
So I reread the [docs](https://download.libsodium.org/doc/helpers/padding.html) on the padding function and it appears I was somehow confusing myself before. Byte values that lie further than the unpadded length shouldn't matter and won't cause the padding function to be confused about where the content ends because we of course tell it the unpadded length (for some reason I was worrying about this).
In this case, appending a block worth of zeros to the byte array should be sufficient, and then of course trimming to the padded length after we know it.

This also renames an argument label where I forgot it.