### PR TITLE
Convert to structs where possible and file segmentation

### DIFF
--- a/Sodium/Aead.swift
+++ b/Sodium/Aead.swift
@@ -3,99 +3,105 @@ import Clibsodium
 
 public struct Aead {
     public let xchacha20poly1305ietf = XChaCha20Poly1305Ietf()
-    
+}
+
+extension Aead {
     public struct XChaCha20Poly1305Ietf {
         public let ABytes = Int(crypto_aead_xchacha20poly1305_ietf_abytes())
         public typealias MAC = Bytes
+    }
+}
+
+extension Aead.XChaCha20Poly1305Ietf {
+    /**
+     Encrypts a message with a shared secret key.
+
+     - Parameter message: The message to encrypt.
+     - Parameter secretKey: The shared secret key.
+     - Parameter additionalData: A typical use for these data is to authenticate version numbers, timestamps or monotonically increasing counters
+
+     - Returns: A `Bytes` object containing the nonce and authenticated ciphertext.
+     */
+    public func encrypt(message: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> Bytes? {
+        guard let (authenticatedCipherText, nonce): (Bytes, Nonce) = encrypt(
+            message: message,
+            secretKey: secretKey,
+            additionalData: additionalData
+        ) else { return nil }
+
+        return nonce + authenticatedCipherText
+    }
+
+    /**
+     Encrypts a message with a shared secret key.
+
+     - Parameter message: The message to encrypt.
+     - Parameter secretKey: The shared secret key.
+     - Parameter additionalData: A typical use for these data is to authenticate version numbers, timestamps or monotonically increasing counters
+
+     - Returns: The authenticated ciphertext and encryption nonce.
+     */
+    public func encrypt(message: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> (authenticatedCipherText: Bytes, nonce: Nonce)? {
+        guard secretKey.count == KeyBytes else { return nil }
+
+        var authenticatedCipherText = Bytes(count: message.count + ABytes)
+        var authenticatedCipherTextLen: UInt64 = 0
+        let nonce = self.nonce()
+
+        guard .SUCCESS == crypto_aead_xchacha20poly1305_ietf_encrypt (
+            &authenticatedCipherText, &authenticatedCipherTextLen,
+            message, UInt64(message.count),
+            additionalData, UInt64(additionalData?.count ?? 0),
+            nil, nonce, secretKey
+        ).exitCode else { return nil }
+
+        return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
+    }
+}
+
+extension Aead.XChaCha20Poly1305Ietf {
+    /**
+     Decrypts a message with a shared secret key.
+     
+     - Parameter nonceAndAuthenticatedCipherText: A `Bytes` object containing the nonce and authenticated ciphertext.
+     - Parameter secretKey: The shared secret key.
+     - Parameter additionalData: Must be used same `Bytes` that was used to encrypt, if `Bytes` deferred will return nil
+     
+     - Returns: The decrypted message.
+     */
+    public func decrypt(nonceAndAuthenticatedCipherText: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> Bytes? {
+        guard nonceAndAuthenticatedCipherText.count >= ABytes + NonceBytes else { return nil }
         
-        /**
-         Encrypts a message with a shared secret key.
-         
-         - Parameter message: The message to encrypt.
-         - Parameter secretKey: The shared secret key.
-         - Parameter additionalData: A typical use for these data is to authenticate version numbers, timestamps or monotonically increasing counters
-         
-         - Returns: A `Bytes` object containing the nonce and authenticated ciphertext.
-         */
-        public func encrypt(message: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> Bytes? {
-            guard let (authenticatedCipherText, nonce): (Bytes, Nonce) = encrypt(
-                message: message,
-                secretKey: secretKey,
-                additionalData: additionalData
-            ) else { return nil }
+        let nonce = nonceAndAuthenticatedCipherText[..<NonceBytes].bytes as Nonce
+        let authenticatedCipherText = nonceAndAuthenticatedCipherText[NonceBytes...].bytes
 
-            return nonce + authenticatedCipherText
-        }
-        
-        /**
-         Encrypts a message with a shared secret key.
-         
-         - Parameter message: The message to encrypt.
-         - Parameter secretKey: The shared secret key.
-         - Parameter additionalData: A typical use for these data is to authenticate version numbers, timestamps or monotonically increasing counters
-         
-         - Returns: The authenticated ciphertext and encryption nonce.
-         */
-        public func encrypt(message: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> (authenticatedCipherText: Bytes, nonce: Nonce)? {
-            guard secretKey.count == KeyBytes else { return nil }
-
-            var authenticatedCipherText = Bytes(count: message.count + ABytes)
-            var authenticatedCipherTextLen: UInt64 = 0
-            let nonce = self.nonce()
-
-            guard .SUCCESS == crypto_aead_xchacha20poly1305_ietf_encrypt (
-                &authenticatedCipherText, &authenticatedCipherTextLen,
-                message, UInt64(message.count),
-                additionalData, UInt64(additionalData?.count ?? 0),
-                nil, nonce, secretKey
-            ).exitCode else { return nil }
+        return decrypt(authenticatedCipherText: authenticatedCipherText, secretKey: secretKey, nonce: nonce, additionalData: additionalData)
+    }
     
-            return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
-        }
-
-        /**
-         Decrypts a message with a shared secret key.
-         
-         - Parameter nonceAndAuthenticatedCipherText: A `Bytes` object containing the nonce and authenticated ciphertext.
-         - Parameter secretKey: The shared secret key.
-         - Parameter additionalData: Must be used same `Bytes` that was used to encrypt, if `Bytes` deferred will return nil
-         
-         - Returns: The decrypted message.
-         */
-        public func decrypt(nonceAndAuthenticatedCipherText: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> Bytes? {
-            guard nonceAndAuthenticatedCipherText.count >= ABytes + NonceBytes else { return nil }
-            
-            let nonce = nonceAndAuthenticatedCipherText[..<NonceBytes].bytes as Nonce
-            let authenticatedCipherText = nonceAndAuthenticatedCipherText[NonceBytes...].bytes
-
-            return decrypt(authenticatedCipherText: authenticatedCipherText, secretKey: secretKey, nonce: nonce, additionalData: additionalData)
-        }
+    /**
+     Decrypts a message with a shared secret key.
+     
+     - Parameter authenticatedCipherText: A `Bytes` object containing authenticated ciphertext.
+     - Parameter secretKey: The shared secret key.
+     - Parameter additionalData: Must be used same `Bytes` that was used to encrypt, if `Bytes` deferred will return nil
+     
+     - Returns: The decrypted message.
+     */
+    public func decrypt(authenticatedCipherText: Bytes, secretKey: Key, nonce: Nonce, additionalData: Bytes? = nil) -> Bytes? {
+        guard authenticatedCipherText.count >= ABytes else { return nil }
         
-        /**
-         Decrypts a message with a shared secret key.
-         
-         - Parameter authenticatedCipherText: A `Bytes` object containing authenticated ciphertext.
-         - Parameter secretKey: The shared secret key.
-         - Parameter additionalData: Must be used same `Bytes` that was used to encrypt, if `Bytes` deferred will return nil
-         
-         - Returns: The decrypted message.
-         */
-        public func decrypt(authenticatedCipherText: Bytes, secretKey: Key, nonce: Nonce, additionalData: Bytes? = nil) -> Bytes? {
-            guard authenticatedCipherText.count >= ABytes else { return nil }
-            
-            var message = Bytes(count: authenticatedCipherText.count - ABytes)
-            var messageLen: UInt64 = 0
+        var message = Bytes(count: authenticatedCipherText.count - ABytes)
+        var messageLen: UInt64 = 0
 
-            guard .SUCCESS == crypto_aead_xchacha20poly1305_ietf_decrypt (
-                &message, &messageLen,
-                nil,
-                authenticatedCipherText, UInt64(authenticatedCipherText.count),
-                additionalData, UInt64(additionalData?.count ?? 0),
-                nonce, secretKey
-            ).exitCode else { return nil }
-    
-            return message
-        }
+        guard .SUCCESS == crypto_aead_xchacha20poly1305_ietf_decrypt (
+            &message, &messageLen,
+            nil,
+            authenticatedCipherText, UInt64(authenticatedCipherText.count),
+            additionalData, UInt64(additionalData?.count ?? 0),
+            nonce, secretKey
+        ).exitCode else { return nil }
+
+        return message
     }
 }
 

--- a/Sodium/Aead.swift
+++ b/Sodium/Aead.swift
@@ -4,7 +4,7 @@ import Clibsodium
 public struct Aead {
     public let xchacha20poly1305ietf = XChaCha20Poly1305Ietf()
     
-    public class XChaCha20Poly1305Ietf {
+    public struct XChaCha20Poly1305Ietf {
         public let ABytes = Int(crypto_aead_xchacha20poly1305_ietf_abytes())
         public typealias MAC = Bytes
         

--- a/Sodium/Auth.swift
+++ b/Sodium/Auth.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class Auth {
+public struct Auth {
     public let Bytes = Int(crypto_auth_bytes())
     public typealias SecretKey = Key
 

--- a/Sodium/Auth.swift
+++ b/Sodium/Auth.swift
@@ -4,7 +4,9 @@ import Clibsodium
 public struct Auth {
     public let Bytes = Int(crypto_auth_bytes())
     public typealias SecretKey = Key
+}
 
+extension Auth {
     /**
      Computes an authentication tag for a message using a key
 

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -9,7 +9,9 @@ public struct Box {
 
     public typealias MAC = Bytes
     public typealias Beforenm = Bytes
+}
 
+extension Box {
     /**
      Encrypts a message with a recipient's public key and a sender's secret key.
 
@@ -116,6 +118,69 @@ public struct Box {
     }
 
     /**
+     Encrypts a message with the shared secret key generated from a recipient's public key and a sender's secret key using `beforenm()`.
+
+     - Parameter message: The message to encrypt.
+     - Parameter beforenm: The shared secret key.
+
+     - Returns: The authenticated ciphertext and encryption nonce.
+     */
+    public func seal(message: Bytes, beforenm: Beforenm) -> (authenticatedCipherText: Bytes, nonce: Nonce)? {
+        guard beforenm.count == BeforenmBytes else { return nil }
+        var authenticatedCipherText = Bytes(count: message.count + MacBytes)
+        let nonce = self.nonce()
+
+        guard .SUCCESS == crypto_box_easy_afternm (
+            &authenticatedCipherText,
+            message, UInt64(message.count),
+            nonce,
+            beforenm
+        ).exitCode else { return nil }
+
+        return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
+    }
+
+    /**
+     Encrypts a message with the shared secret key generated from a recipient's public key and a sender's secret key using `beforenm()`.
+
+     - Parameter message: The message to encrypt.
+     - Parameter beforenm: The shared secret key.
+
+     - Returns: A `Bytes` object containing the encryption nonce and authenticated ciphertext.
+     */
+    public func seal(message: Bytes, beforenm: Beforenm) -> Bytes? {
+        guard let (authenticatedCipherText, nonce): (Bytes, Nonce) = seal(
+            message: message,
+            beforenm: beforenm
+        ) else { return nil }
+
+        return nonce + authenticatedCipherText
+    }
+
+    /**
+     Encrypts a message with a recipient's public key.
+
+     - Parameter message: The message to encrypt.
+     - Parameter recipientPublicKey: The recipient's public key.
+
+     - Returns: The anonymous ciphertext.
+     */
+    public func seal(message: Bytes, recipientPublicKey: Box.PublicKey) -> Bytes? {
+        guard recipientPublicKey.count == PublicKeyBytes else { return nil }
+        var anonymousCipherText = Bytes(count: SealBytes + message.count)
+
+        guard .SUCCESS == crypto_box_seal (
+            &anonymousCipherText,
+            message, UInt64(message.count),
+            recipientPublicKey
+        ).exitCode else { return nil }
+
+        return anonymousCipherText
+    }
+}
+
+extension Box {
+    /**
      Decrypts a message with a sender's public key and the recipient's secret key.
 
      - Parameter nonceAndAuthenticatedCipherText: A `Bytes` object containing the nonce and authenticated ciphertext.
@@ -196,50 +261,6 @@ public struct Box {
     }
 
     /**
-     Computes a shared secret key given a public key and a secret key.
-
-     Applications that send several messages to the same receiver or receive several messages from the same sender can gain speed by calculating the shared key only once, and reusing it in subsequent operations.
-
-     - Parameter recipientPublicKey: The recipient's public key.
-     - Parameter senderSecretKey: The sender's secret key.
-
-     - Returns: The computed shared secret key.
-     */
-    public func beforenm(recipientPublicKey: PublicKey, senderSecretKey: SecretKey) -> Bytes? {
-        var key = Bytes(count: BeforenmBytes)
-        guard .SUCCESS == crypto_box_beforenm (
-            &key,
-            recipientPublicKey,
-            senderSecretKey
-        ).exitCode else { return nil }
-
-        return key
-    }
-
-    /**
-     Encrypts a message with the shared secret key generated from a recipient's public key and a sender's secret key using `beforenm()`.
-
-     - Parameter message: The message to encrypt.
-     - Parameter beforenm: The shared secret key.
-
-     - Returns: The authenticated ciphertext and encryption nonce.
-     */
-    public func seal(message: Bytes, beforenm: Beforenm) -> (authenticatedCipherText: Bytes, nonce: Nonce)? {
-        guard beforenm.count == BeforenmBytes else { return nil }
-        var authenticatedCipherText = Bytes(count: message.count + MacBytes)
-        let nonce = self.nonce()
-
-        guard .SUCCESS == crypto_box_easy_afternm (
-            &authenticatedCipherText,
-            message, UInt64(message.count),
-            nonce,
-            beforenm
-        ).exitCode else { return nil }
-
-        return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
-    }
-
-    /**
      Decrypts a message with the shared secret key generated from a recipient's public key and a sender's secret key using `beforenm()`.
 
      - Parameter nonceAndAuthenticatedCipherText: A `Bytes` object containing the nonce and authenticated ciphertext.
@@ -284,44 +305,6 @@ public struct Box {
     }
 
     /**
-     Encrypts a message with the shared secret key generated from a recipient's public key and a sender's secret key using `beforenm()`.
-
-     - Parameter message: The message to encrypt.
-     - Parameter beforenm: The shared secret key.
-
-     - Returns: A `Bytes` object containing the encryption nonce and authenticated ciphertext.
-     */
-    public func seal(message: Bytes, beforenm: Beforenm) -> Bytes? {
-        guard let (authenticatedCipherText, nonce): (Bytes, Nonce) = seal(
-            message: message,
-            beforenm: beforenm
-        ) else { return nil }
-
-        return nonce + authenticatedCipherText
-    }
-
-    /**
-     Encrypts a message with a recipient's public key.
-
-     - Parameter message: The message to encrypt.
-     - Parameter recipientPublicKey: The recipient's public key.
-
-     - Returns: The anonymous ciphertext.
-     */
-    public func seal(message: Bytes, recipientPublicKey: Box.PublicKey) -> Bytes? {
-        guard recipientPublicKey.count == PublicKeyBytes else { return nil }
-        var anonymousCipherText = Bytes(count: SealBytes + message.count)
-
-        guard .SUCCESS == crypto_box_seal (
-            &anonymousCipherText,
-            message, UInt64(message.count),
-            recipientPublicKey
-        ).exitCode else { return nil }
-
-        return anonymousCipherText
-    }
-
-    /**
      Decrypts a message with the recipient's public key and secret key.
 
      - Parameter anonymousCipherText: A `Bytes` object containing the anonymous ciphertext.
@@ -346,6 +329,29 @@ public struct Box {
         ).exitCode else { return nil }
 
         return message
+    }
+}
+
+extension Box {
+    /**
+     Computes a shared secret key given a public key and a secret key.
+
+     Applications that send several messages to the same receiver or receive several messages from the same sender can gain speed by calculating the shared key only once, and reusing it in subsequent operations.
+
+     - Parameter recipientPublicKey: The recipient's public key.
+     - Parameter senderSecretKey: The sender's secret key.
+
+     - Returns: The computed shared secret key.
+     */
+    public func beforenm(recipientPublicKey: PublicKey, senderSecretKey: SecretKey) -> Bytes? {
+        var key = Bytes(count: BeforenmBytes)
+        guard .SUCCESS == crypto_box_beforenm (
+            &key,
+            recipientPublicKey,
+            senderSecretKey
+        ).exitCode else { return nil }
+
+        return key
     }
 }
 

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -355,6 +355,7 @@ extension Box {
     }
 }
 
+
 extension Box: KeyPairGenerator {
     public typealias PublicKey = Bytes
     public typealias SecretKey = Bytes

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class Box {
+public struct Box {
     public let MacBytes = Int(crypto_box_macbytes())
     public let Primitive = String(validatingUTF8:crypto_box_primitive())
     public let BeforenmBytes = Int(crypto_box_beforenmbytes())

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class GenericHash {
+public struct GenericHash {
     public let BytesMin = Int(crypto_generichash_bytes_min())
     public let BytesMax = Int(crypto_generichash_bytes_max())
     public let Bytes = Int(crypto_generichash_bytes())

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -12,6 +12,32 @@ public struct GenericHash {
 }
 
 extension GenericHash {
+    public class Stream {
+        private var state: UnsafeMutablePointer<State>
+        public var outputLength: Int = 0
+
+        init?(key: Bytes?, outputLength: Int) {
+            state = Stream.generate()
+
+            guard .SUCCESS == crypto_generichash_init(
+                state,
+                key, key?.count ?? 0,
+                outputLength
+            ).exitCode else {
+                    free()
+                    return nil
+            }
+
+            self.outputLength = outputLength
+        }
+
+        deinit {
+            free()
+        }
+    }
+}
+
+extension GenericHash {
     /**
      Computes a fixed-length fingerprint for an arbitrary long message. A key can also be specified. A message will always have the same fingerprint for a given key, but different keys used to hash the same message are very likely to produce distinct fingerprints.
 
@@ -91,32 +117,6 @@ extension GenericHash {
      */
     public func initStream(outputLength: Int) -> Stream? {
         return Stream(key: nil, outputLength: outputLength)
-    }
-}
-
-extension GenericHash {
-    public class Stream {
-        private var state: UnsafeMutablePointer<State>
-        public var outputLength: Int = 0
-
-        init?(key: Bytes?, outputLength: Int) {
-            state = Stream.generate()
-
-            guard .SUCCESS == crypto_generichash_init(
-                state,
-                key, key?.count ?? 0,
-                outputLength
-            ).exitCode else {
-                free()
-                return nil
-            }
-
-            self.outputLength = outputLength
-        }
-
-        deinit {
-            free()
-        }
     }
 }
 

--- a/Sodium/KeyDerivation.swift
+++ b/Sodium/KeyDerivation.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class KeyDerivation {
+public struct KeyDerivation {
     public let BytesMin = Int(crypto_kdf_bytes_min())
     public let BytesMax = Int(crypto_kdf_bytes_max())
     public let ContextBytes = Int(crypto_kdf_contextbytes())

--- a/Sodium/KeyDerivation.swift
+++ b/Sodium/KeyDerivation.swift
@@ -7,7 +7,9 @@ public struct KeyDerivation {
     public let ContextBytes = Int(crypto_kdf_contextbytes())
 
     public typealias SubKey = Bytes
+}
 
+extension KeyDerivation {
     /**
      Derives a subkey from the specified input key. Each index (from 0 to (2^64) - 1) yields a unique deterministic subkey.
      The sequence of subkeys is likely unique for a given context.

--- a/Sodium/KeyExchange.swift
+++ b/Sodium/KeyExchange.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class KeyExchange {
+public struct KeyExchange {
     public let SessionKeyBytes = Int(crypto_kx_sessionkeybytes())
 
     public struct SessionKeyPair {

--- a/Sodium/KeyExchange.swift
+++ b/Sodium/KeyExchange.swift
@@ -3,7 +3,9 @@ import Clibsodium
 
 public struct KeyExchange {
     public let SessionKeyBytes = Int(crypto_kx_sessionkeybytes())
+}
 
+extension KeyExchange {
     public struct SessionKeyPair {
         public let rx: Bytes
         public let tx: Bytes
@@ -13,7 +15,9 @@ public struct KeyExchange {
             self.tx = tx
         }
     }
+}
 
+extension KeyExchange {
     public enum Side {
         case CLIENT
         case SERVER
@@ -31,7 +35,9 @@ public struct KeyExchange {
             }
         }
     }
+}
 
+extension KeyExchange {
     /**
      Using this function, two parties can securely compute a set of shared keys using their peer's public key and their own secret key.
      See [libsodium.org/doc/key_exchange](https://download.libsodium.org/doc/key_exchange) for more details.

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class PWHash {
+public struct PWHash {
     public let SaltBytes = Int(crypto_pwhash_saltbytes())
     public let StrBytes = Int(crypto_pwhash_strbytes()) - (1 as Int)
     public let StrPrefix = String(validatingUTF8: crypto_pwhash_strprefix())

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -11,21 +11,27 @@ public struct PWHash {
     public let MemLimitInteractive = Int(crypto_pwhash_memlimit_interactive())
     public let MemLimitModerate = Int(crypto_pwhash_memlimit_moderate())
     public let MemLimitSensitive = Int(crypto_pwhash_memlimit_sensitive())
+}
 
+extension PWHash {
     public enum Alg {
         case Default
         case Argon2I13
         case Argon2ID13
+    }
+}
 
-        var id: Int32 {
-            switch self {
-            case .Default:    return crypto_pwhash_alg_default()
-            case .Argon2I13:  return crypto_pwhash_alg_argon2i13()
-            case .Argon2ID13: return crypto_pwhash_alg_argon2id13()
-            }
+extension PWHash.Alg {
+    var id: Int32 {
+        switch self {
+        case .Default:    return crypto_pwhash_alg_default()
+        case .Argon2I13:  return crypto_pwhash_alg_argon2i13()
+        case .Argon2ID13: return crypto_pwhash_alg_argon2id13()
         }
     }
+}
 
+extension PWHash {
     /**
      Generates an ASCII encoded string, which includes:
 
@@ -90,7 +96,9 @@ public struct PWHash {
             size_t(memLimit)
         ).exitCode
     }
+}
 
+extension PWHash {
     /**
      Derives a key from a password and a salt using the Argon2 password hashing function.
 

--- a/Sodium/RandomBytes.swift
+++ b/Sodium/RandomBytes.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class RandomBytes {
+public struct RandomBytes {
     public let SeedBytes = Int(randombytes_seedbytes())
 
     /**

--- a/Sodium/RandomBytes.swift
+++ b/Sodium/RandomBytes.swift
@@ -3,7 +3,9 @@ import Clibsodium
 
 public struct RandomBytes {
     public let SeedBytes = Int(randombytes_seedbytes())
+}
 
+extension RandomBytes {
     /**
      Returns a `Bytes object of length `length` containing an unpredictable sequence of bytes.
 

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class SecretBox {
+public struct SecretBox {
     public let MacBytes = Int(crypto_secretbox_macbytes())
     public typealias MAC = Bytes
 

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -4,7 +4,9 @@ import Clibsodium
 public struct SecretBox {
     public let MacBytes = Int(crypto_secretbox_macbytes())
     public typealias MAC = Bytes
+}
 
+extension SecretBox {
     /**
      Encrypts a message with a shared secret key.
 
@@ -69,7 +71,9 @@ public struct SecretBox {
 
         return (cipherText: cipherText, nonce: nonce, mac: mac)
     }
+}
 
+extension SecretBox {
     /**
      Decrypts a message with a shared secret key.
 
@@ -143,6 +147,7 @@ extension SecretBox: NonceGenerator {
     public var NonceBytes: Int { return Int(crypto_secretbox_noncebytes()) }
     public typealias Nonce = Bytes
 }
+
 extension SecretBox: SecretKeyGenerator {
     public typealias Key = Bytes
     public var KeyBytes: Int { return Int(crypto_secretbox_keybytes()) }

--- a/Sodium/SecretStream.swift
+++ b/Sodium/SecretStream.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class SecretStream {
+public struct SecretStream {
     public let xchacha20poly1305 = XChaCha20Poly1305()
 
     public class XChaCha20Poly1305 {

--- a/Sodium/SecretStream.swift
+++ b/Sodium/SecretStream.swift
@@ -3,180 +3,210 @@ import Clibsodium
 
 public struct SecretStream {
     public let xchacha20poly1305 = XChaCha20Poly1305()
+}
 
-    public class XChaCha20Poly1305 {
+extension SecretStream {
+    public struct XChaCha20Poly1305 {
         public static let ABytes = Int(crypto_secretstream_xchacha20poly1305_abytes())
         public static let HeaderBytes = Int(crypto_secretstream_xchacha20poly1305_headerbytes())
         public static let KeyBytes = Int(crypto_secretstream_xchacha20poly1305_keybytes())
-        public enum Tag: UInt8 {
-            case MESSAGE = 0x00
-            case PUSH = 0x01
-            case REKEY = 0x02
-            case FINAL = 0x03
-        }
         public typealias Header = Bytes
+    }
+}
 
-        /**
-         Creates a new stream using the secret key `secretKey`
+extension SecretStream.XChaCha20Poly1305 {
+    public enum Tag: UInt8 {
+        case MESSAGE = 0x00
+        case PUSH = 0x01
+        case REKEY = 0x02
+        case FINAL = 0x03
+    }
+}
 
-         - Parameter secretKey: The secret key.
+extension SecretStream.XChaCha20Poly1305 {
+    /**
+     Creates a new stream using the secret key `secretKey`
 
-         - Returns: A `PushStreamObject`. The stream header can be obtained by
-         calling the `header()` method of that returned object.
-         */
-        public func initPush(secretKey: Key) -> PushStream? {
-            return PushStream(secretKey: secretKey)
-        }
+     - Parameter secretKey: The secret key.
 
-        /**
-         Starts reading a stream, whose header is `header`.
+     - Returns: A `PushStreamObject`. The stream header can be obtained by
+     calling the `header()` method of that returned object.
+     */
+    public func initPush(secretKey: Key) -> PushStream? {
+        return PushStream(secretKey: secretKey)
+    }
 
-         - Parameter secretKey: The secret key.
-         - Parameter header: The header.
+    /**
+     Starts reading a stream, whose header is `header`.
 
-         - Returns: The stream to decrypt messages from.
-         */
-        public func initPull(secretKey: Key, header: Header) -> PullStream? {
-            return PullStream(secretKey: secretKey, header: header)
-        }
+     - Parameter secretKey: The secret key.
+     - Parameter header: The header.
 
-        public class PushStream: StateStream {
-            typealias State = crypto_secretstream_xchacha20poly1305_state
+     - Returns: The stream to decrypt messages from.
+     */
+    public func initPull(secretKey: Key, header: Header) -> PullStream? {
+        return PullStream(secretKey: secretKey, header: header)
+    }
+}
 
-            static let capacity = crypto_secretstream_xchacha20poly1305_statebytes()
-            private var state: UnsafeMutablePointer<State>
+extension SecretStream.XChaCha20Poly1305 {
+    public class PushStream {
+        private var state: UnsafeMutablePointer<State>
+        private var _header: Header
 
-            private var _header: Header
+        init?(secretKey: Key) {
+            guard secretKey.count == KeyBytes else { return nil }
 
-            init?(secretKey: Key) {
-                guard secretKey.count == KeyBytes else { return nil }
-
-                state = PushStream.generate()
-                _header = Bytes(count: HeaderBytes)
-                guard .SUCCESS == crypto_secretstream_xchacha20poly1305_init_push(
-                    state,
-                    &_header,
-                    secretKey
-                ).exitCode else {
-                    free()
-                    return nil
-                }
-            }
-
-            /**
-             The header of the stream, required to decrypt it.
-
-             - Returns: The stream header.
-             */
-            public func header() -> Header {
-                return _header
-            }
-
-            /**
-             Encrypts and authenticate a new message. Optionally also authenticate `ad`.
-
-             - Parameter message: The message to encrypt.
-             - Parameter tag: The tag to attach to the message. By default `.MESSAGE`.
-             You may want to use `.FINAL` for the last message of the stream instead.
-             - Parameter ad: Optional additional data to authenticate.
-
-             - Returns: The ciphertext.
-             */
-            public func push(message: Bytes, tag: Tag = .MESSAGE, ad: Bytes? = nil) -> Bytes? {
-                let _ad = ad ?? Bytes(count: 0)
-                var cipherText = Bytes(count: message.count + ABytes)
-                guard .SUCCESS == crypto_secretstream_xchacha20poly1305_push(
-                    state,
-                    &cipherText,
-                    nil,
-                    message, UInt64(message.count),
-                    _ad, UInt64(_ad.count),
-                    tag.rawValue
-                ).exitCode else { return nil }
-
-                return cipherText
-            }
-
-            /**
-             Performs an explicit key rotation.
-             */
-            public func rekey() {
-                crypto_secretstream_xchacha20poly1305_rekey(state)
-            }
-
-            private func free() {
-                PushStream.free(state)
-            }
-
-            deinit {
+            state = PushStream.generate()
+            _header = Bytes(count: HeaderBytes)
+            guard .SUCCESS == crypto_secretstream_xchacha20poly1305_init_push(
+                state,
+                &_header,
+                secretKey
+            ).exitCode else {
                 free()
+                return nil
             }
         }
 
-        public class PullStream: StateStream {
-            typealias State = crypto_secretstream_xchacha20poly1305_state
+        deinit {
+            free()
+        }
+    }
+}
 
-            static let capacity = crypto_secretstream_xchacha20poly1305_statebytes()
-            private var state: UnsafeMutablePointer<State>
+extension SecretStream.XChaCha20Poly1305.PushStream: StateStream {
+    typealias State = crypto_secretstream_xchacha20poly1305_state
+    static let capacity = crypto_secretstream_xchacha20poly1305_statebytes()
+}
 
-            init?(secretKey: Key, header: Header) {
-                guard header.count == HeaderBytes, secretKey.count == KeyBytes else {
-                    return nil
-                }
-                state = PushStream.generate()
-                guard .SUCCESS == crypto_secretstream_xchacha20poly1305_init_pull(
-                    state,
-                    header,
-                    secretKey
-                ).exitCode else {
-                    free()
-                    return nil
-                }
+extension SecretStream.XChaCha20Poly1305.PushStream {
+    public typealias Header = SecretStream.XChaCha20Poly1305.Header
+
+    /**
+     The header of the stream, required to decrypt it.
+
+     - Returns: The stream header.
+     */
+    public func header() -> Header {
+        return _header
+    }
+}
+
+extension SecretStream.XChaCha20Poly1305.PushStream {
+    public typealias Tag = SecretStream.XChaCha20Poly1305.Tag
+    typealias XChaCha20Poly1305 = SecretStream.XChaCha20Poly1305
+
+    /**
+     Encrypts and authenticate a new message. Optionally also authenticate `ad`.
+
+     - Parameter message: The message to encrypt.
+     - Parameter tag: The tag to attach to the message. By default `.MESSAGE`.
+     You may want to use `.FINAL` for the last message of the stream instead.
+     - Parameter ad: Optional additional data to authenticate.
+
+     - Returns: The ciphertext.
+     */
+    public func push(message: Bytes, tag: Tag = .MESSAGE, ad: Bytes? = nil) -> Bytes? {
+        let _ad = ad ?? Bytes(count: 0)
+        var cipherText = Bytes(count: message.count + XChaCha20Poly1305.ABytes)
+        guard .SUCCESS == crypto_secretstream_xchacha20poly1305_push(
+            state,
+            &cipherText,
+            nil,
+            message, UInt64(message.count),
+            _ad, UInt64(_ad.count),
+            tag.rawValue
+        ).exitCode else { return nil }
+
+        return cipherText
+    }
+
+    /**
+     Performs an explicit key rotation.
+     */
+    public func rekey() {
+        crypto_secretstream_xchacha20poly1305_rekey(state)
+    }
+}
+
+extension SecretStream.XChaCha20Poly1305.PushStream {
+    private func free() {
+        XChaCha20Poly1305.PushStream.free(state)
+    }
+}
+
+extension SecretStream.XChaCha20Poly1305 {
+    public class PullStream: StateStream {
+        typealias State = crypto_secretstream_xchacha20poly1305_state
+
+        static let capacity = crypto_secretstream_xchacha20poly1305_statebytes()
+        private var state: UnsafeMutablePointer<State>
+
+        init?(secretKey: Key, header: Header) {
+            guard header.count == HeaderBytes, secretKey.count == KeyBytes else {
+                return nil
             }
-
-            /**
-             Decrypts a new message off the stream.
-
-             - Parameter cipherText: The encrypted message.
-             - Parameter ad: Optional additional data to authenticate.
-
-             - Returns: The decrypted message, as well as the tag attached to it.
-             */
-            public func pull(cipherText: Bytes, ad: Bytes? = nil) -> (Bytes, Tag)? {
-                guard cipherText.count >= ABytes else { return nil }
-                var message = Bytes(count: cipherText.count - ABytes)
-                let _ad = ad ?? Bytes(count: 0)
-                var _tag: UInt8 = 0
-                let result = crypto_secretstream_xchacha20poly1305_pull(
-                    state,
-                    &message,
-                    nil,
-                    &_tag,
-                    cipherText, UInt64(cipherText.count),
-                    _ad, UInt64(_ad.count)
-                ).exitCode
-
-                guard result == .SUCCESS, let tag = Tag(rawValue: _tag) else {
-                    return nil
-                }
-                return (message, tag)
-            }
-
-            /**
-             Performs an explicit key rotation.
-             */
-            public func rekey() {
-                crypto_secretstream_xchacha20poly1305_rekey(state)
-            }
-
-            private func free() {
-                PullStream.free(state)
-            }
-
-            deinit {
+            state = PushStream.generate()
+            guard .SUCCESS == crypto_secretstream_xchacha20poly1305_init_pull(
+                state,
+                header,
+                secretKey
+            ).exitCode else {
                 free()
+                return nil
             }
         }
+
+        deinit {
+            free()
+        }
+    }
+}
+
+extension SecretStream.XChaCha20Poly1305.PullStream {
+    public typealias Tag = SecretStream.XChaCha20Poly1305.Tag
+    typealias XChaCha20Poly1305 = SecretStream.XChaCha20Poly1305
+
+    /**
+     Decrypts a new message off the stream.
+
+     - Parameter cipherText: The encrypted message.
+     - Parameter ad: Optional additional data to authenticate.
+
+     - Returns: The decrypted message, as well as the tag attached to it.
+     */
+    public func pull(cipherText: Bytes, ad: Bytes? = nil) -> (Bytes, Tag)? {
+        guard cipherText.count >= ABytes else { return nil }
+        var message = Bytes(count: cipherText.count - XChaCha20Poly1305.ABytes)
+        let _ad = ad ?? Bytes(count: 0)
+        var _tag: UInt8 = 0
+        let result = crypto_secretstream_xchacha20poly1305_pull(
+            state,
+            &message,
+            nil,
+            &_tag,
+            cipherText, UInt64(cipherText.count),
+            _ad, UInt64(_ad.count)
+        ).exitCode
+
+        guard result == .SUCCESS, let tag = Tag(rawValue: _tag) else {
+            return nil
+        }
+        return (message, tag)
+    }
+
+    /**
+     Performs an explicit key rotation.
+     */
+    public func rekey() {
+        crypto_secretstream_xchacha20poly1305_rekey(state)
+    }
+}
+
+extension SecretStream.XChaCha20Poly1305.PullStream {
+    private func free() {
+        XChaCha20Poly1305.PullStream.free(state)
     }
 }
 

--- a/Sodium/ShortHash.swift
+++ b/Sodium/ShortHash.swift
@@ -3,7 +3,9 @@ import Clibsodium
 
 public struct ShortHash {
     public let Bytes = Int(crypto_shorthash_bytes())
+}
 
+extension ShortHash {
     /**
      Computes short but unpredictable (without knowing the secret key) values suitable for picking a list in a hash table for a given key.
 

--- a/Sodium/ShortHash.swift
+++ b/Sodium/ShortHash.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class ShortHash {
+public struct ShortHash {
     public let Bytes = Int(crypto_shorthash_bytes())
 
     /**

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class Sign {
+public struct Sign {
     public let Bytes = Int(crypto_sign_bytes())
     public let Primitive = String(validatingUTF8: crypto_sign_primitive())
 

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -4,7 +4,9 @@ import Clibsodium
 public struct Sign {
     public let Bytes = Int(crypto_sign_bytes())
     public let Primitive = String(validatingUTF8: crypto_sign_primitive())
+}
 
+extension Sign {
     /**
      Signs a message with the sender's secret key
 
@@ -48,7 +50,9 @@ public struct Sign {
 
         return signature
     }
+}
 
+extension Sign {
     /**
      Verifies a signed message with the sender's public key.
 
@@ -84,7 +88,9 @@ public struct Sign {
             publicKey
         ).exitCode
     }
+}
 
+extension Sign {
     /**
      Extracts and returns the message data of a signed message if the signature is verified with the sender's secret key.
 

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -17,13 +17,15 @@ public struct Sodium {
     public let secretStream = SecretStream()
     public let aead = Aead()
 
+    public init() {
+        _ = Sodium.once
+    }
+}
+
+extension Sodium {
     private static let once: Void = {
         guard sodium_init() >= 0 else {
             fatalError("Failed to initialize libsodium")
         }
     }()
-
-    public init() {
-        _ = Sodium.once
-    }
 }

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class Sodium {
+public struct Sodium {
     public let box = Box()
     public let secretBox = SecretBox()
     public let genericHash = GenericHash()

--- a/Sodium/Stream.swift
+++ b/Sodium/Stream.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class Stream {
+public struct Stream {
     public let Primitive = String(validatingUTF8: crypto_stream_primitive())
 
     /**

--- a/Sodium/Stream.swift
+++ b/Sodium/Stream.swift
@@ -3,7 +3,9 @@ import Clibsodium
 
 public struct Stream {
     public let Primitive = String(validatingUTF8: crypto_stream_primitive())
+}
 
+extension Stream {
     /**
      XOR the input with a key stream derived from a secret key and a nonce.
      Applying the same operation twice outputs the original input.

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -11,6 +11,9 @@ public struct Utils {
         let count = data.count
         sodium_memzero(&data, count)
     }
+}
+
+extension Utils {
 
     /**
      Checks that two `Bytes` objects have the same content, without leaking information
@@ -39,7 +42,9 @@ public struct Utils {
         guard b1.count == b2.count else { return nil }
         return Int(sodium_compare(b1, b2, b1.count))
     }
+}
 
+extension Utils {
     /**
      Converts bytes stored in `bin` into a hexadecimal string.
 
@@ -85,14 +90,18 @@ public struct Utils {
 
         return binBytes
     }
+}
 
+extension Utils {
     public enum Base64Variant: CInt {
         case ORIGINAL            = 1
         case ORIGINAL_NO_PADDING = 3
         case URLSAFE             = 5
         case URLSAFE_NO_PADDING  = 7
     }
+}
 
+extension Utils {
     /**
      Converts bytes stored in `bin` into a Base64 representation.
 
@@ -140,7 +149,9 @@ public struct Utils {
 
         return binBytes
     }
+}
 
+extension Utils {
     /*
      Adds padding to `data` so that its length becomes a multiple of `blockSize`
 

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class Utils {
+public struct Utils {
     /**
      Tries to effectively zero bytes in `data`, even if optimizations are being applied to the code.
 

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -1,7 +1,18 @@
 import Foundation
 import Clibsodium
 
-public struct Utils {
+public struct Utils {}
+
+extension Utils {
+    public enum Base64Variant: CInt {
+        case ORIGINAL            = 1
+        case ORIGINAL_NO_PADDING = 3
+        case URLSAFE             = 5
+        case URLSAFE_NO_PADDING  = 7
+    }
+}
+
+extension Utils {
     /**
      Tries to effectively zero bytes in `data`, even if optimizations are being applied to the code.
 
@@ -89,15 +100,6 @@ extension Utils {
         binBytes = binBytes[..<binBytesLen].bytes
 
         return binBytes
-    }
-}
-
-extension Utils {
-    public enum Base64Variant: CInt {
-        case ORIGINAL            = 1
-        case ORIGINAL_NO_PADDING = 3
-        case URLSAFE             = 5
-        case URLSAFE_NO_PADDING  = 7
     }
 }
 


### PR DESCRIPTION
In Swift we have [value types](https://developer.apple.com/videos/play/wwdc2015/408), so classes are often overkill – I've left them in for now for things implementing `StateStream` because they directly hold onto a pointer and we want to proactively free our internal state when deinitialisation occurs. For everything else, we don't need classes :)

I've also segmented each document into (IMO) some sensible groups by utilising extensions to implement each section of the types.