### PR TITLE
[WIP] BytesRepresentable protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ let secretkey = sodium.secretStream.xchacha20poly1305.key()
 
 /* stream encryption */
 
-let stream_enc = sodium.secretStream.xchacha20poly1305.initPush(secretKey: secretkey)!
+var stream_enc = sodium.secretStream.xchacha20poly1305.initPush(secretKey: secretkey)!
 let header = stream_enc.header()
 let encrypted1 = stream_enc.push(message: message1)!
 let encrypted2 = stream_enc.push(message: message2)!
@@ -59,7 +59,7 @@ let encrypted3 = stream_enc.push(message: message3, tag: .FINAL)!
 
 /* stream decryption */
 
-let stream_dec = sodium.secretStream.xchacha20poly1305.initPull(secretKey: secretkey, header: header)!
+var stream_dec = sodium.secretStream.xchacha20poly1305.initPull(secretKey: secretkey, header: header)!
 let (message1_dec, tag1) = stream_dec.pull(cipherText: encrypted1)!
 let (message2_dec, tag2) = stream_dec.pull(cipherText: encrypted2)!
 let (message3_dec, tag3) = stream_dec.pull(cipherText: encrypted3)!
@@ -220,7 +220,7 @@ let sodium = Sodium()
 let message1 = "My Test ".bytes
 let message2 = "Message".bytes
 let key = "Secret key".bytes
-let stream = sodium.genericHash.initStream(key: key)!
+var stream = sodium.genericHash.initStream(key: key)!
 stream.update(input: message1)
 stream.update(input: message2)
 let h = stream.final()

--- a/Sodium.xcodeproj/project.pbxproj
+++ b/Sodium.xcodeproj/project.pbxproj
@@ -61,6 +61,12 @@
 		DD1E4D07208E744100BE7A3F /* StateStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1E4D05208E744100BE7A3F /* StateStream.swift */; };
 		DD1E4D0F20922C9E00BE7A3F /* ExitCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1E4D0E20922C9E00BE7A3F /* ExitCode.swift */; };
 		DD1E4D1020922C9E00BE7A3F /* ExitCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1E4D0E20922C9E00BE7A3F /* ExitCode.swift */; };
+		DD1FE64E2094B888007907E3 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1FE64D2094B888007907E3 /* String+Extension.swift */; };
+		DD1FE64F2094B888007907E3 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1FE64D2094B888007907E3 /* String+Extension.swift */; };
+		DD1FE6512094B9DD007907E3 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1FE6502094B9DD007907E3 /* Array+Extension.swift */; };
+		DD1FE6522094B9DD007907E3 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1FE6502094B9DD007907E3 /* Array+Extension.swift */; };
+		DD1FE6542094BA3D007907E3 /* BytesRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1FE6532094BA3D007907E3 /* BytesRepresentable.swift */; };
+		DD1FE6552094BA3D007907E3 /* BytesRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1FE6532094BA3D007907E3 /* BytesRepresentable.swift */; };
 		DD35BB5020924A35006BF351 /* NonceGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB4F20924A35006BF351 /* NonceGenerator.swift */; };
 		DD35BB5120924A35006BF351 /* NonceGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB4F20924A35006BF351 /* NonceGenerator.swift */; };
 		DD35BB5320924B6F006BF351 /* KeyPairGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB5220924B6F006BF351 /* KeyPairGenerator.swift */; };
@@ -71,6 +77,10 @@
 		DD35BB5B20925566006BF351 /* SecretKeyGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB5920925566006BF351 /* SecretKeyGenerator.swift */; };
 		DD35BB6320932A83006BF351 /* Bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB6220932A83006BF351 /* Bytes.swift */; };
 		DD35BB6420932A83006BF351 /* Bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB6220932A83006BF351 /* Bytes.swift */; };
+		DD92AD092094BD9100F7A743 /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD92AD082094BD9100F7A743 /* Data+Extension.swift */; };
+		DD92AD0A2094BD9100F7A743 /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD92AD082094BD9100F7A743 /* Data+Extension.swift */; };
+		DD92AD0C2094D06200F7A743 /* ArraySlice+BytesRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD92AD0B2094D06200F7A743 /* ArraySlice+BytesRepresentable.swift */; };
+		DD92AD0D2094D06200F7A743 /* ArraySlice+BytesRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD92AD0B2094D06200F7A743 /* ArraySlice+BytesRepresentable.swift */; };
 		F87EEC402063C655006C830D /* Aead.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87EEC3F2063C655006C830D /* Aead.swift */; };
 /* End PBXBuildFile section */
 
@@ -208,11 +218,16 @@
 		D85101051E22F77E003DB2E8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		DD1E4D05208E744100BE7A3F /* StateStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateStream.swift; sourceTree = "<group>"; };
 		DD1E4D0E20922C9E00BE7A3F /* ExitCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExitCode.swift; sourceTree = "<group>"; };
+		DD1FE64D2094B888007907E3 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
+		DD1FE6502094B9DD007907E3 /* Array+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extension.swift"; sourceTree = "<group>"; };
+		DD1FE6532094BA3D007907E3 /* BytesRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BytesRepresentable.swift; sourceTree = "<group>"; };
 		DD35BB4F20924A35006BF351 /* NonceGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonceGenerator.swift; sourceTree = "<group>"; };
 		DD35BB5220924B6F006BF351 /* KeyPairGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPairGenerator.swift; sourceTree = "<group>"; };
 		DD35BB5520924D3A006BF351 /* KeyPairProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPairProtocol.swift; sourceTree = "<group>"; };
 		DD35BB5920925566006BF351 /* SecretKeyGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretKeyGenerator.swift; sourceTree = "<group>"; };
 		DD35BB6220932A83006BF351 /* Bytes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bytes.swift; sourceTree = "<group>"; };
+		DD92AD082094BD9100F7A743 /* Data+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extension.swift"; sourceTree = "<group>"; };
+		DD92AD0B2094D06200F7A743 /* ArraySlice+BytesRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArraySlice+BytesRepresentable.swift"; sourceTree = "<group>"; };
 		F87EEC3F2063C655006C830D /* Aead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Aead.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -293,6 +308,8 @@
 				09A943CC1A4EB5F500C8A04F /* Sodium.h */,
 				094F21E91A5017CA001C3141 /* Box.swift */,
 				DD35BB6220932A83006BF351 /* Bytes.swift */,
+				DD1FE6532094BA3D007907E3 /* BytesRepresentable.swift */,
+				DD1FE64C2094B82C007907E3 /* BytesRepresentables */,
 				DD35BB58209252BF006BF351 /* Generators */,
 				DD1E4D0E20922C9E00BE7A3F /* ExitCode.swift */,
 				DD1E4D05208E744100BE7A3F /* StateStream.swift */,
@@ -468,6 +485,17 @@
 				901645021AE376C100163E3E /* Helpers.swift */,
 			);
 			name = CommonCode;
+			sourceTree = "<group>";
+		};
+		DD1FE64C2094B82C007907E3 /* BytesRepresentables */ = {
+			isa = PBXGroup;
+			children = (
+				DD1FE64D2094B888007907E3 /* String+Extension.swift */,
+				DD1FE6502094B9DD007907E3 /* Array+Extension.swift */,
+				DD92AD082094BD9100F7A743 /* Data+Extension.swift */,
+				DD92AD0B2094D06200F7A743 /* ArraySlice+BytesRepresentable.swift */,
+			);
+			path = BytesRepresentables;
 			sourceTree = "<group>";
 		};
 		DD35BB58209252BF006BF351 /* Generators */ = {
@@ -703,14 +731,17 @@
 				095D80551A4ECCD7000B83F9 /* Sodium.swift in Sources */,
 				097F20DA1AF127480088C2FE /* PWHash.swift in Sources */,
 				DD1E4D0F20922C9E00BE7A3F /* ExitCode.swift in Sources */,
+				DD92AD0C2094D06200F7A743 /* ArraySlice+BytesRepresentable.swift in Sources */,
 				038365151A5A51D20081136D /* SecretBox.swift in Sources */,
 				095D805D1A4F4F72000B83F9 /* Utils.swift in Sources */,
 				DD35BB5A20925566006BF351 /* SecretKeyGenerator.swift in Sources */,
 				091C7CDC1A50839D002E5351 /* Sign.swift in Sources */,
+				DD1FE6512094B9DD007907E3 /* Array+Extension.swift in Sources */,
 				DD35BB5320924B6F006BF351 /* KeyPairGenerator.swift in Sources */,
 				A0918C781E92489100C1DC33 /* Auth.swift in Sources */,
 				DD1E4D06208E744100BE7A3F /* StateStream.swift in Sources */,
 				094298301EDDAA3B001236B1 /* Stream.swift in Sources */,
+				DD1FE64E2094B888007907E3 /* String+Extension.swift in Sources */,
 				D2A274061F13AD9300958702 /* KeyDerivation.swift in Sources */,
 				DD35BB6320932A83006BF351 /* Bytes.swift in Sources */,
 				09A5AC121F74466700D3200B /* SecretStream.swift in Sources */,
@@ -718,6 +749,8 @@
 				091C7CDA1A507E95002E5351 /* ShortHash.swift in Sources */,
 				095D805B1A4F35CA000B83F9 /* RandomBytes.swift in Sources */,
 				095D80571A4ED0B4000B83F9 /* GenericHash.swift in Sources */,
+				DD92AD092094BD9100F7A743 /* Data+Extension.swift in Sources */,
+				DD1FE6542094BA3D007907E3 /* BytesRepresentable.swift in Sources */,
 				DD35BB5620924D3A006BF351 /* KeyPairProtocol.swift in Sources */,
 				F87EEC402063C655006C830D /* Aead.swift in Sources */,
 				094F21EA1A5017CA001C3141 /* Box.swift in Sources */,
@@ -762,12 +795,17 @@
 				CFD847281BA8120900B1260F /* PWHash.swift in Sources */,
 				DD35BB5420924B6F006BF351 /* KeyPairGenerator.swift in Sources */,
 				DD35BB5120924A35006BF351 /* NonceGenerator.swift in Sources */,
+				DD92AD0A2094BD9100F7A743 /* Data+Extension.swift in Sources */,
 				90C75EE71AE3583E00F1E749 /* GenericHash.swift in Sources */,
 				90C75EE91AE3583E00F1E749 /* RandomBytes.swift in Sources */,
+				DD1FE6552094BA3D007907E3 /* BytesRepresentable.swift in Sources */,
+				DD1FE6522094B9DD007907E3 /* Array+Extension.swift in Sources */,
 				DD35BB5720924D3A006BF351 /* KeyPairProtocol.swift in Sources */,
 				60C211E71EB73D3900882AD0 /* Auth.swift in Sources */,
+				DD92AD0D2094D06200F7A743 /* ArraySlice+BytesRepresentable.swift in Sources */,
 				094298311EDDAA3B001236B1 /* Stream.swift in Sources */,
 				DD1E4D07208E744100BE7A3F /* StateStream.swift in Sources */,
+				DD1FE64F2094B888007907E3 /* String+Extension.swift in Sources */,
 				DD1E4D1020922C9E00BE7A3F /* ExitCode.swift in Sources */,
 				DD35BB6420932A83006BF351 /* Bytes.swift in Sources */,
 				6096E7321F194FA800E6599F /* KeyDerivation.swift in Sources */,

--- a/Sodium/Aead.swift
+++ b/Sodium/Aead.swift
@@ -3,99 +3,105 @@ import Clibsodium
 
 public struct Aead {
     public let xchacha20poly1305ietf = XChaCha20Poly1305Ietf()
-    
+}
+
+extension Aead {
     public struct XChaCha20Poly1305Ietf {
         public let ABytes = Int(crypto_aead_xchacha20poly1305_ietf_abytes())
         public typealias MAC = Bytes
+    }
+}
+
+extension Aead.XChaCha20Poly1305Ietf {
+    /**
+     Encrypts a message with a shared secret key.
+
+     - Parameter message: The message to encrypt.
+     - Parameter secretKey: The shared secret key.
+     - Parameter additionalData: A typical use for these data is to authenticate version numbers, timestamps or monotonically increasing counters
+
+     - Returns: A `Bytes` object containing the nonce and authenticated ciphertext.
+     */
+    public func encrypt(message: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> Bytes? {
+        guard let (authenticatedCipherText, nonce): (Bytes, Nonce) = encrypt(
+            message: message,
+            secretKey: secretKey,
+            additionalData: additionalData
+        ) else { return nil }
+
+        return nonce + authenticatedCipherText
+    }
+
+    /**
+     Encrypts a message with a shared secret key.
+
+     - Parameter message: The message to encrypt.
+     - Parameter secretKey: The shared secret key.
+     - Parameter additionalData: A typical use for these data is to authenticate version numbers, timestamps or monotonically increasing counters
+
+     - Returns: The authenticated ciphertext and encryption nonce.
+     */
+    public func encrypt(message: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> (authenticatedCipherText: Bytes, nonce: Nonce)? {
+        guard secretKey.count == KeyBytes else { return nil }
+
+        var authenticatedCipherText = Bytes(count: message.count + ABytes)
+        var authenticatedCipherTextLen: UInt64 = 0
+        let nonce = self.nonce()
+
+        guard .SUCCESS == crypto_aead_xchacha20poly1305_ietf_encrypt (
+            &authenticatedCipherText, &authenticatedCipherTextLen,
+            message, UInt64(message.count),
+            additionalData, UInt64(additionalData?.count ?? 0),
+            nil, nonce, secretKey
+        ).exitCode else { return nil }
+
+        return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
+    }
+}
+
+extension Aead.XChaCha20Poly1305Ietf {
+    /**
+     Decrypts a message with a shared secret key.
+     
+     - Parameter nonceAndAuthenticatedCipherText: A `Bytes` object containing the nonce and authenticated ciphertext.
+     - Parameter secretKey: The shared secret key.
+     - Parameter additionalData: Must be used same `Bytes` that was used to encrypt, if `Bytes` deferred will return nil
+     
+     - Returns: The decrypted message.
+     */
+    public func decrypt(nonceAndAuthenticatedCipherText: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> Bytes? {
+        guard nonceAndAuthenticatedCipherText.count >= ABytes + NonceBytes else { return nil }
         
-        /**
-         Encrypts a message with a shared secret key.
-         
-         - Parameter message: The message to encrypt.
-         - Parameter secretKey: The shared secret key.
-         - Parameter additionalData: A typical use for these data is to authenticate version numbers, timestamps or monotonically increasing counters
-         
-         - Returns: A `Bytes` object containing the nonce and authenticated ciphertext.
-         */
-        public func encrypt(message: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> Bytes? {
-            guard let (authenticatedCipherText, nonce): (Bytes, Nonce) = encrypt(
-                message: message,
-                secretKey: secretKey,
-                additionalData: additionalData
-            ) else { return nil }
+        let nonce = nonceAndAuthenticatedCipherText[..<NonceBytes].bytes as Nonce
+        let authenticatedCipherText = nonceAndAuthenticatedCipherText[NonceBytes...].bytes
 
-            return nonce + authenticatedCipherText
-        }
-        
-        /**
-         Encrypts a message with a shared secret key.
-         
-         - Parameter message: The message to encrypt.
-         - Parameter secretKey: The shared secret key.
-         - Parameter additionalData: A typical use for these data is to authenticate version numbers, timestamps or monotonically increasing counters
-         
-         - Returns: The authenticated ciphertext and encryption nonce.
-         */
-        public func encrypt(message: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> (authenticatedCipherText: Bytes, nonce: Nonce)? {
-            guard secretKey.count == KeyBytes else { return nil }
-
-            var authenticatedCipherText = Bytes(count: message.count + ABytes)
-            var authenticatedCipherTextLen: UInt64 = 0
-            let nonce = self.nonce()
-
-            guard .SUCCESS == crypto_aead_xchacha20poly1305_ietf_encrypt (
-                &authenticatedCipherText, &authenticatedCipherTextLen,
-                message, UInt64(message.count),
-                additionalData, UInt64(additionalData?.count ?? 0),
-                nil, nonce, secretKey
-            ).exitCode else { return nil }
+        return decrypt(authenticatedCipherText: authenticatedCipherText, secretKey: secretKey, nonce: nonce, additionalData: additionalData)
+    }
     
-            return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
-        }
-
-        /**
-         Decrypts a message with a shared secret key.
-         
-         - Parameter nonceAndAuthenticatedCipherText: A `Bytes` object containing the nonce and authenticated ciphertext.
-         - Parameter secretKey: The shared secret key.
-         - Parameter additionalData: Must be used same `Bytes` that was used to encrypt, if `Bytes` deferred will return nil
-         
-         - Returns: The decrypted message.
-         */
-        public func decrypt(nonceAndAuthenticatedCipherText: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> Bytes? {
-            guard nonceAndAuthenticatedCipherText.count >= ABytes + NonceBytes else { return nil }
-            
-            let nonce = nonceAndAuthenticatedCipherText[..<NonceBytes].bytes as Nonce
-            let authenticatedCipherText = nonceAndAuthenticatedCipherText[NonceBytes...].bytes
-
-            return decrypt(authenticatedCipherText: authenticatedCipherText, secretKey: secretKey, nonce: nonce, additionalData: additionalData)
-        }
+    /**
+     Decrypts a message with a shared secret key.
+     
+     - Parameter authenticatedCipherText: A `Bytes` object containing authenticated ciphertext.
+     - Parameter secretKey: The shared secret key.
+     - Parameter additionalData: Must be used same `Bytes` that was used to encrypt, if `Bytes` deferred will return nil
+     
+     - Returns: The decrypted message.
+     */
+    public func decrypt(authenticatedCipherText: Bytes, secretKey: Key, nonce: Nonce, additionalData: Bytes? = nil) -> Bytes? {
+        guard authenticatedCipherText.count >= ABytes else { return nil }
         
-        /**
-         Decrypts a message with a shared secret key.
-         
-         - Parameter authenticatedCipherText: A `Bytes` object containing authenticated ciphertext.
-         - Parameter secretKey: The shared secret key.
-         - Parameter additionalData: Must be used same `Bytes` that was used to encrypt, if `Bytes` deferred will return nil
-         
-         - Returns: The decrypted message.
-         */
-        public func decrypt(authenticatedCipherText: Bytes, secretKey: Key, nonce: Nonce, additionalData: Bytes? = nil) -> Bytes? {
-            guard authenticatedCipherText.count >= ABytes else { return nil }
-            
-            var message = Bytes(count: authenticatedCipherText.count - ABytes)
-            var messageLen: UInt64 = 0
+        var message = Bytes(count: authenticatedCipherText.count - ABytes)
+        var messageLen: UInt64 = 0
 
-            guard .SUCCESS == crypto_aead_xchacha20poly1305_ietf_decrypt (
-                &message, &messageLen,
-                nil,
-                authenticatedCipherText, UInt64(authenticatedCipherText.count),
-                additionalData, UInt64(additionalData?.count ?? 0),
-                nonce, secretKey
-            ).exitCode else { return nil }
-    
-            return message
-        }
+        guard .SUCCESS == crypto_aead_xchacha20poly1305_ietf_decrypt (
+            &message, &messageLen,
+            nil,
+            authenticatedCipherText, UInt64(authenticatedCipherText.count),
+            additionalData, UInt64(additionalData?.count ?? 0),
+            nonce, secretKey
+        ).exitCode else { return nil }
+
+        return message
     }
 }
 

--- a/Sodium/Aead.swift
+++ b/Sodium/Aead.swift
@@ -22,7 +22,7 @@ extension Aead.XChaCha20Poly1305Ietf {
 
      - Returns: A `Bytes` object containing the nonce and authenticated ciphertext.
      */
-    public func encrypt(message: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> Bytes? {
+    public func encrypt(message: BytesRepresentable, secretKey: Key, additionalData: BytesRepresentable? = nil) -> Bytes? {
         guard let (authenticatedCipherText, nonce): (Bytes, Nonce) = encrypt(
             message: message,
             secretKey: secretKey,
@@ -41,9 +41,10 @@ extension Aead.XChaCha20Poly1305Ietf {
 
      - Returns: The authenticated ciphertext and encryption nonce.
      */
-    public func encrypt(message: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> (authenticatedCipherText: Bytes, nonce: Nonce)? {
+    public func encrypt(message: BytesRepresentable, secretKey: Key, additionalData: BytesRepresentable? = nil) -> (authenticatedCipherText: Bytes, nonce: Nonce)? {
         guard secretKey.count == KeyBytes else { return nil }
 
+        let (message, additionalData) = (message.bytes, additionalData?.bytes)
         var authenticatedCipherText = Bytes(count: message.count + ABytes)
         var authenticatedCipherTextLen: UInt64 = 0
         let nonce = self.nonce()
@@ -69,7 +70,9 @@ extension Aead.XChaCha20Poly1305Ietf {
      
      - Returns: The decrypted message.
      */
-    public func decrypt(nonceAndAuthenticatedCipherText: Bytes, secretKey: Key, additionalData: Bytes? = nil) -> Bytes? {
+    public func decrypt(nonceAndAuthenticatedCipherText: BytesRepresentable, secretKey: Key, additionalData: BytesRepresentable? = nil) -> Bytes? {
+        let nonceAndAuthenticatedCipherText = nonceAndAuthenticatedCipherText.bytes
+        let additionalData = additionalData?.bytes
         guard nonceAndAuthenticatedCipherText.count >= ABytes + NonceBytes else { return nil }
         
         let nonce = nonceAndAuthenticatedCipherText[..<NonceBytes].bytes as Nonce
@@ -87,7 +90,9 @@ extension Aead.XChaCha20Poly1305Ietf {
      
      - Returns: The decrypted message.
      */
-    public func decrypt(authenticatedCipherText: Bytes, secretKey: Key, nonce: Nonce, additionalData: Bytes? = nil) -> Bytes? {
+    public func decrypt(authenticatedCipherText: BytesRepresentable, secretKey: Key, nonce: Nonce, additionalData: BytesRepresentable? = nil) -> Bytes? {
+        let authenticatedCipherText = authenticatedCipherText.bytes
+        let additionalData = additionalData?.bytes
         guard authenticatedCipherText.count >= ABytes else { return nil }
         
         var message = Bytes(count: authenticatedCipherText.count - ABytes)

--- a/Sodium/Aead.swift
+++ b/Sodium/Aead.swift
@@ -4,7 +4,7 @@ import Clibsodium
 public struct Aead {
     public let xchacha20poly1305ietf = XChaCha20Poly1305Ietf()
     
-    public class XChaCha20Poly1305Ietf {
+    public struct XChaCha20Poly1305Ietf {
         public let ABytes = Int(crypto_aead_xchacha20poly1305_ietf_abytes())
         public typealias MAC = Bytes
         

--- a/Sodium/Auth.swift
+++ b/Sodium/Auth.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class Auth {
+public struct Auth {
     public let Bytes = Int(crypto_auth_bytes())
     public typealias SecretKey = Key
 

--- a/Sodium/Auth.swift
+++ b/Sodium/Auth.swift
@@ -15,9 +15,10 @@ extension Auth {
 
      - Returns: The computed authentication tag.
      */
-    public func tag(message: Bytes, secretKey: SecretKey) -> Bytes? {
+    public func tag(message: BytesRepresentable, secretKey: SecretKey) -> Bytes? {
         guard secretKey.count == KeyBytes else { return nil }
 
+        let message = message.bytes
         var tag = Array<UInt8>(count: Bytes)
         guard .SUCCESS == crypto_auth (
             &tag,
@@ -37,10 +38,11 @@ extension Auth {
 
      - Returns: `true` if the verification is successful.
      */
-    public func verify(message: Bytes, secretKey: SecretKey, tag: Bytes) -> Bool {
+    public func verify(message: BytesRepresentable, secretKey: SecretKey, tag: BytesRepresentable) -> Bool {
         guard secretKey.count == KeyBytes else {
             return false
         }
+        let (tag, message) = (tag.bytes, message.bytes)
         return .SUCCESS == crypto_auth_verify (
             tag,
             message, UInt64(message.count),

--- a/Sodium/Auth.swift
+++ b/Sodium/Auth.swift
@@ -4,7 +4,9 @@ import Clibsodium
 public struct Auth {
     public let Bytes = Int(crypto_auth_bytes())
     public typealias SecretKey = Key
+}
 
+extension Auth {
     /**
      Computes an authentication tag for a message using a key
 

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -9,7 +9,9 @@ public struct Box {
 
     public typealias MAC = Bytes
     public typealias Beforenm = Bytes
+}
 
+extension Box {
     /**
      Encrypts a message with a recipient's public key and a sender's secret key.
 
@@ -116,6 +118,69 @@ public struct Box {
     }
 
     /**
+     Encrypts a message with the shared secret key generated from a recipient's public key and a sender's secret key using `beforenm()`.
+
+     - Parameter message: The message to encrypt.
+     - Parameter beforenm: The shared secret key.
+
+     - Returns: The authenticated ciphertext and encryption nonce.
+     */
+    public func seal(message: Bytes, beforenm: Beforenm) -> (authenticatedCipherText: Bytes, nonce: Nonce)? {
+        guard beforenm.count == BeforenmBytes else { return nil }
+        var authenticatedCipherText = Bytes(count: message.count + MacBytes)
+        let nonce = self.nonce()
+
+        guard .SUCCESS == crypto_box_easy_afternm (
+            &authenticatedCipherText,
+            message, UInt64(message.count),
+            nonce,
+            beforenm
+        ).exitCode else { return nil }
+
+        return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
+    }
+
+    /**
+     Encrypts a message with the shared secret key generated from a recipient's public key and a sender's secret key using `beforenm()`.
+
+     - Parameter message: The message to encrypt.
+     - Parameter beforenm: The shared secret key.
+
+     - Returns: A `Bytes` object containing the encryption nonce and authenticated ciphertext.
+     */
+    public func seal(message: Bytes, beforenm: Beforenm) -> Bytes? {
+        guard let (authenticatedCipherText, nonce): (Bytes, Nonce) = seal(
+            message: message,
+            beforenm: beforenm
+        ) else { return nil }
+
+        return nonce + authenticatedCipherText
+    }
+
+    /**
+     Encrypts a message with a recipient's public key.
+
+     - Parameter message: The message to encrypt.
+     - Parameter recipientPublicKey: The recipient's public key.
+
+     - Returns: The anonymous ciphertext.
+     */
+    public func seal(message: Bytes, recipientPublicKey: Box.PublicKey) -> Bytes? {
+        guard recipientPublicKey.count == PublicKeyBytes else { return nil }
+        var anonymousCipherText = Bytes(count: SealBytes + message.count)
+
+        guard .SUCCESS == crypto_box_seal (
+            &anonymousCipherText,
+            message, UInt64(message.count),
+            recipientPublicKey
+        ).exitCode else { return nil }
+
+        return anonymousCipherText
+    }
+}
+
+extension Box {
+    /**
      Decrypts a message with a sender's public key and the recipient's secret key.
 
      - Parameter nonceAndAuthenticatedCipherText: A `Bytes` object containing the nonce and authenticated ciphertext.
@@ -196,50 +261,6 @@ public struct Box {
     }
 
     /**
-     Computes a shared secret key given a public key and a secret key.
-
-     Applications that send several messages to the same receiver or receive several messages from the same sender can gain speed by calculating the shared key only once, and reusing it in subsequent operations.
-
-     - Parameter recipientPublicKey: The recipient's public key.
-     - Parameter senderSecretKey: The sender's secret key.
-
-     - Returns: The computed shared secret key.
-     */
-    public func beforenm(recipientPublicKey: PublicKey, senderSecretKey: SecretKey) -> Bytes? {
-        var key = Bytes(count: BeforenmBytes)
-        guard .SUCCESS == crypto_box_beforenm (
-            &key,
-            recipientPublicKey,
-            senderSecretKey
-        ).exitCode else { return nil }
-
-        return key
-    }
-
-    /**
-     Encrypts a message with the shared secret key generated from a recipient's public key and a sender's secret key using `beforenm()`.
-
-     - Parameter message: The message to encrypt.
-     - Parameter beforenm: The shared secret key.
-
-     - Returns: The authenticated ciphertext and encryption nonce.
-     */
-    public func seal(message: Bytes, beforenm: Beforenm) -> (authenticatedCipherText: Bytes, nonce: Nonce)? {
-        guard beforenm.count == BeforenmBytes else { return nil }
-        var authenticatedCipherText = Bytes(count: message.count + MacBytes)
-        let nonce = self.nonce()
-
-        guard .SUCCESS == crypto_box_easy_afternm (
-            &authenticatedCipherText,
-            message, UInt64(message.count),
-            nonce,
-            beforenm
-        ).exitCode else { return nil }
-
-        return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
-    }
-
-    /**
      Decrypts a message with the shared secret key generated from a recipient's public key and a sender's secret key using `beforenm()`.
 
      - Parameter nonceAndAuthenticatedCipherText: A `Bytes` object containing the nonce and authenticated ciphertext.
@@ -284,44 +305,6 @@ public struct Box {
     }
 
     /**
-     Encrypts a message with the shared secret key generated from a recipient's public key and a sender's secret key using `beforenm()`.
-
-     - Parameter message: The message to encrypt.
-     - Parameter beforenm: The shared secret key.
-
-     - Returns: A `Bytes` object containing the encryption nonce and authenticated ciphertext.
-     */
-    public func seal(message: Bytes, beforenm: Beforenm) -> Bytes? {
-        guard let (authenticatedCipherText, nonce): (Bytes, Nonce) = seal(
-            message: message,
-            beforenm: beforenm
-        ) else { return nil }
-
-        return nonce + authenticatedCipherText
-    }
-
-    /**
-     Encrypts a message with a recipient's public key.
-
-     - Parameter message: The message to encrypt.
-     - Parameter recipientPublicKey: The recipient's public key.
-
-     - Returns: The anonymous ciphertext.
-     */
-    public func seal(message: Bytes, recipientPublicKey: Box.PublicKey) -> Bytes? {
-        guard recipientPublicKey.count == PublicKeyBytes else { return nil }
-        var anonymousCipherText = Bytes(count: SealBytes + message.count)
-
-        guard .SUCCESS == crypto_box_seal (
-            &anonymousCipherText,
-            message, UInt64(message.count),
-            recipientPublicKey
-        ).exitCode else { return nil }
-
-        return anonymousCipherText
-    }
-
-    /**
      Decrypts a message with the recipient's public key and secret key.
 
      - Parameter anonymousCipherText: A `Bytes` object containing the anonymous ciphertext.
@@ -346,6 +329,29 @@ public struct Box {
         ).exitCode else { return nil }
 
         return message
+    }
+}
+
+extension Box {
+    /**
+     Computes a shared secret key given a public key and a secret key.
+
+     Applications that send several messages to the same receiver or receive several messages from the same sender can gain speed by calculating the shared key only once, and reusing it in subsequent operations.
+
+     - Parameter recipientPublicKey: The recipient's public key.
+     - Parameter senderSecretKey: The sender's secret key.
+
+     - Returns: The computed shared secret key.
+     */
+    public func beforenm(recipientPublicKey: PublicKey, senderSecretKey: SecretKey) -> Bytes? {
+        var key = Bytes(count: BeforenmBytes)
+        guard .SUCCESS == crypto_box_beforenm (
+            &key,
+            recipientPublicKey,
+            senderSecretKey
+        ).exitCode else { return nil }
+
+        return key
     }
 }
 

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -355,6 +355,7 @@ extension Box {
     }
 }
 
+
 extension Box: KeyPairGenerator {
     public typealias PublicKey = Bytes
     public typealias SecretKey = Bytes

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class Box {
+public struct Box {
     public let MacBytes = Int(crypto_box_macbytes())
     public let Primitive = String(validatingUTF8:crypto_box_primitive())
     public let BeforenmBytes = Int(crypto_box_beforenmbytes())

--- a/Sodium/Bytes.swift
+++ b/Sodium/Bytes.swift
@@ -6,16 +6,6 @@ extension Array where Element == UInt8 {
     init (count bytes: Int) {
         self.init(repeating: 0, count: bytes)
     }
-
-    public var utf8String: String? {
-        return String(data: Data(bytes: self), encoding: .utf8)
-    }
 }
 
-extension ArraySlice where Element == UInt8 {
-    var bytes: Bytes { return Bytes(self) }
-}
 
-public extension String {
-    var bytes: Bytes { return Bytes(self.utf8) }
-}

--- a/Sodium/BytesRepresentable.swift
+++ b/Sodium/BytesRepresentable.swift
@@ -1,0 +1,10 @@
+public protocol BytesRepresentable {
+    var bytes: [UInt8] { get }
+    init? (bytes: [UInt8])
+}
+
+public extension BytesRepresentable {
+    init? (bytes: BytesRepresentable) {
+        self.init(bytes: bytes.bytes)
+    }
+}

--- a/Sodium/BytesRepresentables/Array+Extension.swift
+++ b/Sodium/BytesRepresentables/Array+Extension.swift
@@ -1,0 +1,7 @@
+extension Array: BytesRepresentable where Element == UInt8 {
+    public var bytes: [UInt8] { return self }
+
+    public init (bytes: [UInt8]) {
+        self = bytes
+    }
+}

--- a/Sodium/BytesRepresentables/ArraySlice+BytesRepresentable.swift
+++ b/Sodium/BytesRepresentables/ArraySlice+BytesRepresentable.swift
@@ -1,0 +1,7 @@
+extension ArraySlice: BytesRepresentable where Element == UInt8 {
+    public var bytes: [UInt8] { return Array(self) }
+
+    public init (bytes: [UInt8]) {
+        self.init(bytes)
+    }
+}

--- a/Sodium/BytesRepresentables/Data+Extension.swift
+++ b/Sodium/BytesRepresentables/Data+Extension.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension Data: BytesRepresentable {
+    public var bytes: [UInt8] { return Array(self) }
+}

--- a/Sodium/BytesRepresentables/String+Extension.swift
+++ b/Sodium/BytesRepresentables/String+Extension.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension String: BytesRepresentable {
+    public var bytes: [UInt8] { return Array(self.utf8) }
+
+    public init? (bytes: [UInt8]) {
+        self.init(data: Data(bytes: bytes), encoding: .utf8)
+    }
+}

--- a/Sodium/Generators/KeyPairGenerator.swift
+++ b/Sodium/Generators/KeyPairGenerator.swift
@@ -45,7 +45,8 @@ extension KeyPairGenerator {
 
      - Returns: A key pair containing the secret key and public key.
      */
-    public func keyPair(seed: Bytes) -> KeyPair? {
+    public func keyPair(seed: BytesRepresentable) -> KeyPair? {
+        let seed = seed.bytes
         guard seed.count == SeedBytes else { return nil }
         var pk = Bytes(count: PublicKeyBytes)
         var sk = Bytes(count: SecretKeyBytes)

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -16,9 +16,10 @@ extension GenericHash {
         private var state: State
         public var outputLength: Int = 0
 
-        init?(key: Bytes?, outputLength: Int) {
+        init?(key: BytesRepresentable?, outputLength: Int) {
             state = crypto_generichash_state()
 
+            let key = key?.bytes
             guard .SUCCESS == crypto_generichash_init(
                 &state,
                 key, key?.count ?? 0,
@@ -39,7 +40,7 @@ extension GenericHash {
 
      - Returns: The computed fingerprint.
      */
-    public func hash(message: Bytes, key: Bytes? = nil) -> Bytes? {
+    public func hash(message: BytesRepresentable, key: BytesRepresentable? = nil) -> Bytes? {
         return hash(message: message, key: key, outputLength: Bytes)
     }
 
@@ -52,9 +53,10 @@ extension GenericHash {
 
      - Returns: The computed fingerprint.
      */
-    public func hash(message: Bytes, key: Bytes?, outputLength: Int) -> Bytes? {
+    public func hash(message: BytesRepresentable, key: BytesRepresentable?, outputLength: Int) -> Bytes? {
         var output = Array<UInt8>(count: outputLength)
 
+        let (key, message) = (key?.bytes, message.bytes)
         guard .SUCCESS == crypto_generichash(
             &output, outputLength,
             message, UInt64(message.count),
@@ -72,7 +74,7 @@ extension GenericHash {
 
      - Returns: The computed fingerprint.
      */
-    public func hash(message: Bytes, outputLength: Int) -> Bytes? {
+    public func hash(message: BytesRepresentable, outputLength: Int) -> Bytes? {
         return hash(message: message, key: nil, outputLength: outputLength)
     }
 }
@@ -85,7 +87,7 @@ extension GenericHash {
 
      - Returns: The initialized `Stream`.
      */
-    public func initStream(key: Bytes? = nil) -> Stream? {
+    public func initStream(key: BytesRepresentable? = nil) -> Stream? {
         return Stream(key: key, outputLength: Bytes)
     }
 
@@ -97,7 +99,7 @@ extension GenericHash {
 
      - Returns: The initialized `Stream`.
      */
-    public func initStream(key: Bytes?, outputLength: Int) -> Stream? {
+    public func initStream(key: BytesRepresentable?, outputLength: Int) -> Stream? {
         return Stream(key: key, outputLength: outputLength)
     }
 
@@ -122,7 +124,8 @@ extension GenericHash.Stream {
      - Returns: `true` if the data was consumed successfully.
      */
     @discardableResult
-    public mutating func update(input: Bytes) -> Bool {
+    public mutating func update(input: BytesRepresentable) -> Bool {
+        let input = input.bytes
         return .SUCCESS == crypto_generichash_update(
             &state,
             input, UInt64(input.count)

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class GenericHash {
+public struct GenericHash {
     public let BytesMin = Int(crypto_generichash_bytes_min())
     public let BytesMax = Int(crypto_generichash_bytes_max())
     public let Bytes = Int(crypto_generichash_bytes())

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -12,27 +12,20 @@ public struct GenericHash {
 }
 
 extension GenericHash {
-    public class Stream {
-        private var state: UnsafeMutablePointer<State>
+    public struct Stream {
+        private var state: State
         public var outputLength: Int = 0
 
         init?(key: Bytes?, outputLength: Int) {
-            state = Stream.generate()
+            state = crypto_generichash_state()
 
             guard .SUCCESS == crypto_generichash_init(
-                state,
+                &state,
                 key, key?.count ?? 0,
                 outputLength
-            ).exitCode else {
-                    free()
-                    return nil
-            }
+            ).exitCode else { return nil }
 
             self.outputLength = outputLength
-        }
-
-        deinit {
-            free()
         }
     }
 }
@@ -128,9 +121,10 @@ extension GenericHash.Stream {
 
      - Returns: `true` if the data was consumed successfully.
      */
-    public func update(input: Bytes) -> Bool {
+    @discardableResult
+    public mutating func update(input: Bytes) -> Bool {
         return .SUCCESS == crypto_generichash_update(
-            state,
+            &state,
             input, UInt64(input.count)
         ).exitCode
     }
@@ -140,21 +134,15 @@ extension GenericHash.Stream {
 
      - Returns: The computed fingerprint.
      */
-    public func final() -> Bytes? {
+    public mutating func final() -> Bytes? {
         let outputLen = outputLength
         var output = Array<UInt8>(count: outputLen)
         guard .SUCCESS == crypto_generichash_final(
-            state,
+            &state,
             &output, outputLen
         ).exitCode else { return nil }
 
         return output
-    }
-}
-
-extension GenericHash.Stream {
-    private func free() {
-        GenericHash.Stream.free(state)
     }
 }
 

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -12,6 +12,32 @@ public struct GenericHash {
 }
 
 extension GenericHash {
+    public class Stream {
+        private var state: UnsafeMutablePointer<State>
+        public var outputLength: Int = 0
+
+        init?(key: Bytes?, outputLength: Int) {
+            state = Stream.generate()
+
+            guard .SUCCESS == crypto_generichash_init(
+                state,
+                key, key?.count ?? 0,
+                outputLength
+            ).exitCode else {
+                    free()
+                    return nil
+            }
+
+            self.outputLength = outputLength
+        }
+
+        deinit {
+            free()
+        }
+    }
+}
+
+extension GenericHash {
     /**
      Computes a fixed-length fingerprint for an arbitrary long message. A key can also be specified. A message will always have the same fingerprint for a given key, but different keys used to hash the same message are very likely to produce distinct fingerprints.
 
@@ -91,32 +117,6 @@ extension GenericHash {
      */
     public func initStream(outputLength: Int) -> Stream? {
         return Stream(key: nil, outputLength: outputLength)
-    }
-}
-
-extension GenericHash {
-    public class Stream {
-        private var state: UnsafeMutablePointer<State>
-        public var outputLength: Int = 0
-
-        init?(key: Bytes?, outputLength: Int) {
-            state = Stream.generate()
-
-            guard .SUCCESS == crypto_generichash_init(
-                state,
-                key, key?.count ?? 0,
-                outputLength
-            ).exitCode else {
-                free()
-                return nil
-            }
-
-            self.outputLength = outputLength
-        }
-
-        deinit {
-            free()
-        }
     }
 }
 

--- a/Sodium/KeyDerivation.swift
+++ b/Sodium/KeyDerivation.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class KeyDerivation {
+public struct KeyDerivation {
     public let BytesMin = Int(crypto_kdf_bytes_min())
     public let BytesMax = Int(crypto_kdf_bytes_max())
     public let ContextBytes = Int(crypto_kdf_contextbytes())

--- a/Sodium/KeyDerivation.swift
+++ b/Sodium/KeyDerivation.swift
@@ -7,7 +7,9 @@ public struct KeyDerivation {
     public let ContextBytes = Int(crypto_kdf_contextbytes())
 
     public typealias SubKey = Bytes
+}
 
+extension KeyDerivation {
     /**
      Derives a subkey from the specified input key. Each index (from 0 to (2^64) - 1) yields a unique deterministic subkey.
      The sequence of subkeys is likely unique for a given context.

--- a/Sodium/KeyExchange.swift
+++ b/Sodium/KeyExchange.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class KeyExchange {
+public struct KeyExchange {
     public let SessionKeyBytes = Int(crypto_kx_sessionkeybytes())
 
     public struct SessionKeyPair {

--- a/Sodium/KeyExchange.swift
+++ b/Sodium/KeyExchange.swift
@@ -3,7 +3,9 @@ import Clibsodium
 
 public struct KeyExchange {
     public let SessionKeyBytes = Int(crypto_kx_sessionkeybytes())
+}
 
+extension KeyExchange {
     public struct SessionKeyPair {
         public let rx: Bytes
         public let tx: Bytes
@@ -13,7 +15,9 @@ public struct KeyExchange {
             self.tx = tx
         }
     }
+}
 
+extension KeyExchange {
     public enum Side {
         case CLIENT
         case SERVER
@@ -31,7 +35,9 @@ public struct KeyExchange {
             }
         }
     }
+}
 
+extension KeyExchange {
     /**
      Using this function, two parties can securely compute a set of shared keys using their peer's public key and their own secret key.
      See [libsodium.org/doc/key_exchange](https://download.libsodium.org/doc/key_exchange) for more details.

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -47,9 +47,9 @@ extension PWHash {
 
      - Returns: The generated string.
      */
-    public func str(passwd: Bytes, opsLimit: Int, memLimit: Int) -> String? {
+    public func str(passwd: BytesRepresentable, opsLimit: Int, memLimit: Int) -> String? {
         var output = Bytes(count: StrBytes).map(Int8.init)
-        let passwd = passwd.map(Int8.init)
+        let passwd = passwd.bytes.map(Int8.init)
 
         guard .SUCCESS == crypto_pwhash_str(
             &output,
@@ -69,9 +69,9 @@ extension PWHash {
 
      - Returns: `true` if the verification succeeds.
      */
-    public func strVerify(hash: String, passwd: Bytes) -> Bool {
+    public func strVerify(hash: String, passwd: BytesRepresentable) -> Bool {
         let hashBytes = Bytes((hash + "\0").utf8).map(Int8.init)
-        let passwd = passwd.map(Int8.init)
+        let passwd = passwd.bytes.map(Int8.init)
 
         return .SUCCESS == crypto_pwhash_str_verify(
             hashBytes,
@@ -113,10 +113,10 @@ extension PWHash {
 
      - Returns: The derived key data.
      */
-    public func hash(outputLength: Int, passwd: Bytes, salt: Bytes, opsLimit: Int, memLimit: Int, alg: Alg = .Default) -> Bytes? {
+    public func hash(outputLength: Int, passwd: BytesRepresentable, salt: Bytes, opsLimit: Int, memLimit: Int, alg: Alg = .Default) -> Bytes? {
         guard salt.count == SaltBytes else { return nil }
         var output = Bytes(count: outputLength)
-        let passwd = passwd.map(Int8.init)
+        let passwd = passwd.bytes.map(Int8.init)
 
         guard .SUCCESS == crypto_pwhash(
             &output, UInt64(outputLength),

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class PWHash {
+public struct PWHash {
     public let SaltBytes = Int(crypto_pwhash_saltbytes())
     public let StrBytes = Int(crypto_pwhash_strbytes()) - (1 as Int)
     public let StrPrefix = String(validatingUTF8: crypto_pwhash_strprefix())

--- a/Sodium/PWHash.swift
+++ b/Sodium/PWHash.swift
@@ -11,21 +11,27 @@ public struct PWHash {
     public let MemLimitInteractive = Int(crypto_pwhash_memlimit_interactive())
     public let MemLimitModerate = Int(crypto_pwhash_memlimit_moderate())
     public let MemLimitSensitive = Int(crypto_pwhash_memlimit_sensitive())
+}
 
+extension PWHash {
     public enum Alg {
         case Default
         case Argon2I13
         case Argon2ID13
+    }
+}
 
-        var id: Int32 {
-            switch self {
-            case .Default:    return crypto_pwhash_alg_default()
-            case .Argon2I13:  return crypto_pwhash_alg_argon2i13()
-            case .Argon2ID13: return crypto_pwhash_alg_argon2id13()
-            }
+extension PWHash.Alg {
+    var id: Int32 {
+        switch self {
+        case .Default:    return crypto_pwhash_alg_default()
+        case .Argon2I13:  return crypto_pwhash_alg_argon2i13()
+        case .Argon2ID13: return crypto_pwhash_alg_argon2id13()
         }
     }
+}
 
+extension PWHash {
     /**
      Generates an ASCII encoded string, which includes:
 
@@ -90,7 +96,9 @@ public struct PWHash {
             size_t(memLimit)
         ).exitCode
     }
+}
 
+extension PWHash {
     /**
      Derives a key from a password and a salt using the Argon2 password hashing function.
 

--- a/Sodium/RandomBytes.swift
+++ b/Sodium/RandomBytes.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class RandomBytes {
+public struct RandomBytes {
     public let SeedBytes = Int(randombytes_seedbytes())
 
     /**

--- a/Sodium/RandomBytes.swift
+++ b/Sodium/RandomBytes.swift
@@ -46,7 +46,8 @@ extension RandomBytes {
 
      - Returns: The generated data.
      */
-    public func deterministic(length: Int, seed: Bytes) -> Bytes? {
+    public func deterministic(length: Int, seed: BytesRepresentable) -> Bytes? {
+        let seed = seed.bytes
         guard length >= 0,
               seed.count == SeedBytes,
               Int64(length) <= 0x4000000000 as Int64

--- a/Sodium/RandomBytes.swift
+++ b/Sodium/RandomBytes.swift
@@ -3,7 +3,9 @@ import Clibsodium
 
 public struct RandomBytes {
     public let SeedBytes = Int(randombytes_seedbytes())
+}
 
+extension RandomBytes {
     /**
      Returns a `Bytes object of length `length` containing an unpredictable sequence of bytes.
 

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class SecretBox {
+public struct SecretBox {
     public let MacBytes = Int(crypto_secretbox_macbytes())
     public typealias MAC = Bytes
 

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -4,7 +4,9 @@ import Clibsodium
 public struct SecretBox {
     public let MacBytes = Int(crypto_secretbox_macbytes())
     public typealias MAC = Bytes
+}
 
+extension SecretBox {
     /**
      Encrypts a message with a shared secret key.
 
@@ -69,7 +71,9 @@ public struct SecretBox {
 
         return (cipherText: cipherText, nonce: nonce, mac: mac)
     }
+}
 
+extension SecretBox {
     /**
      Decrypts a message with a shared secret key.
 
@@ -143,6 +147,7 @@ extension SecretBox: NonceGenerator {
     public var NonceBytes: Int { return Int(crypto_secretbox_noncebytes()) }
     public typealias Nonce = Bytes
 }
+
 extension SecretBox: SecretKeyGenerator {
     public typealias Key = Bytes
     public var KeyBytes: Int { return Int(crypto_secretbox_keybytes()) }

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -15,7 +15,7 @@ extension SecretBox {
 
      - Returns: A `Bytes` object containing the nonce and authenticated ciphertext.
      */
-    public func seal(message: Bytes, secretKey: Key) -> Bytes? {
+    public func seal(message: BytesRepresentable, secretKey: Key) -> Bytes? {
         guard let (authenticatedCipherText, nonce): (Bytes, Nonce) = seal(
             message: message,
             secretKey: secretKey
@@ -31,7 +31,8 @@ extension SecretBox {
 
      - Returns: The authenticated ciphertext and encryption nonce.
      */
-    public func seal(message: Bytes, secretKey: Key) -> (authenticatedCipherText: Bytes, nonce: Nonce)? {
+    public func seal(message: BytesRepresentable, secretKey: Key) -> (authenticatedCipherText: Bytes, nonce: Nonce)? {
+        let message = message.bytes
         guard secretKey.count == KeyBytes else { return nil }
         var authenticatedCipherText = Bytes(count: message.count + MacBytes)
         let nonce = self.nonce()
@@ -54,9 +55,10 @@ extension SecretBox {
 
      - Returns: The encrypted ciphertext, encryption nonce, and authentication tag.
      */
-    public func seal(message: Bytes, secretKey: Key) -> (cipherText: Bytes, nonce: Nonce, mac: MAC)? {
+    public func seal(message: BytesRepresentable, secretKey: Key) -> (cipherText: Bytes, nonce: Nonce, mac: MAC)? {
         guard secretKey.count == KeyBytes else { return nil }
 
+        let message = message.bytes
         var cipherText = Bytes(count: message.count)
         var mac = Bytes(count: MacBytes)
         let nonce = self.nonce()
@@ -82,7 +84,8 @@ extension SecretBox {
 
      - Returns: The decrypted message.
      */
-    public func open(nonceAndAuthenticatedCipherText: Bytes, secretKey: Key) -> Bytes? {
+    public func open(nonceAndAuthenticatedCipherText: BytesRepresentable, secretKey: Key) -> Bytes? {
+        let nonceAndAuthenticatedCipherText = nonceAndAuthenticatedCipherText.bytes
         guard nonceAndAuthenticatedCipherText.count >= MacBytes + NonceBytes else { return nil }
         let nonce = nonceAndAuthenticatedCipherText[..<NonceBytes].bytes as Nonce
         let authenticatedCipherText = nonceAndAuthenticatedCipherText[NonceBytes...].bytes
@@ -99,7 +102,8 @@ extension SecretBox {
 
      - Returns: The decrypted message.
      */
-    public func open(authenticatedCipherText: Bytes, secretKey: Key, nonce: Nonce) -> Bytes? {
+    public func open(authenticatedCipherText: BytesRepresentable, secretKey: Key, nonce: Nonce) -> Bytes? {
+        let authenticatedCipherText = authenticatedCipherText.bytes
         guard authenticatedCipherText.count >= MacBytes else { return nil }
         var message = Bytes(count: authenticatedCipherText.count - MacBytes)
 
@@ -122,12 +126,13 @@ extension SecretBox {
 
      - Returns: The decrypted message.
      */
-    public func open(cipherText: Bytes, secretKey: Key, nonce: Nonce, mac: MAC) -> Bytes? {
+    public func open(cipherText: BytesRepresentable, secretKey: Key, nonce: Nonce, mac: MAC) -> Bytes? {
         guard nonce.count == NonceBytes,
               mac.count == MacBytes,
               secretKey.count == KeyBytes
         else { return nil }
 
+        let cipherText = cipherText.bytes
         var message = Bytes(count: cipherText.count)
 
         guard .SUCCESS == crypto_secretbox_open_detached (

--- a/Sodium/SecretStream.swift
+++ b/Sodium/SecretStream.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class SecretStream {
+public struct SecretStream {
     public let xchacha20poly1305 = XChaCha20Poly1305()
 
     public class XChaCha20Poly1305 {

--- a/Sodium/SecretStream.swift
+++ b/Sodium/SecretStream.swift
@@ -120,8 +120,9 @@ extension SecretStream.XChaCha20Poly1305.PushStream {
 
      - Returns: The ciphertext.
      */
-    public mutating func push(message: Bytes, tag: Tag = .MESSAGE, ad: Bytes? = nil) -> Bytes? {
-        let _ad = ad ?? Bytes(count: 0)
+    public mutating func push(message: BytesRepresentable, tag: Tag = .MESSAGE, ad: BytesRepresentable? = nil) -> Bytes? {
+        let _ad = ad?.bytes ?? Bytes(count: 0)
+        let message = message.bytes
         var cipherText = Bytes(count: message.count + XChaCha20Poly1305.ABytes)
         guard .SUCCESS == crypto_secretstream_xchacha20poly1305_push(
             &state,
@@ -155,10 +156,11 @@ extension SecretStream.XChaCha20Poly1305.PullStream {
 
      - Returns: The decrypted message, as well as the tag attached to it.
      */
-    public mutating func pull(cipherText: Bytes, ad: Bytes? = nil) -> (Bytes, Tag)? {
+    public mutating func pull(cipherText: BytesRepresentable, ad: BytesRepresentable? = nil) -> (Bytes, Tag)? {
+        let cipherText = cipherText.bytes
         guard cipherText.count >= XChaCha20Poly1305.ABytes else { return nil }
         var message = Bytes(count: cipherText.count - XChaCha20Poly1305.ABytes)
-        let _ad = ad ?? Bytes(count: 0)
+        let _ad = ad?.bytes ?? Bytes(count: 0)
         var _tag: UInt8 = 0
         let result = crypto_secretstream_xchacha20poly1305_pull(
             &state,

--- a/Sodium/SecretStream.swift
+++ b/Sodium/SecretStream.swift
@@ -3,180 +3,210 @@ import Clibsodium
 
 public struct SecretStream {
     public let xchacha20poly1305 = XChaCha20Poly1305()
+}
 
-    public class XChaCha20Poly1305 {
+extension SecretStream {
+    public struct XChaCha20Poly1305 {
         public static let ABytes = Int(crypto_secretstream_xchacha20poly1305_abytes())
         public static let HeaderBytes = Int(crypto_secretstream_xchacha20poly1305_headerbytes())
         public static let KeyBytes = Int(crypto_secretstream_xchacha20poly1305_keybytes())
-        public enum Tag: UInt8 {
-            case MESSAGE = 0x00
-            case PUSH = 0x01
-            case REKEY = 0x02
-            case FINAL = 0x03
-        }
         public typealias Header = Bytes
+    }
+}
 
-        /**
-         Creates a new stream using the secret key `secretKey`
+extension SecretStream.XChaCha20Poly1305 {
+    public enum Tag: UInt8 {
+        case MESSAGE = 0x00
+        case PUSH = 0x01
+        case REKEY = 0x02
+        case FINAL = 0x03
+    }
+}
 
-         - Parameter secretKey: The secret key.
+extension SecretStream.XChaCha20Poly1305 {
+    /**
+     Creates a new stream using the secret key `secretKey`
 
-         - Returns: A `PushStreamObject`. The stream header can be obtained by
-         calling the `header()` method of that returned object.
-         */
-        public func initPush(secretKey: Key) -> PushStream? {
-            return PushStream(secretKey: secretKey)
-        }
+     - Parameter secretKey: The secret key.
 
-        /**
-         Starts reading a stream, whose header is `header`.
+     - Returns: A `PushStreamObject`. The stream header can be obtained by
+     calling the `header()` method of that returned object.
+     */
+    public func initPush(secretKey: Key) -> PushStream? {
+        return PushStream(secretKey: secretKey)
+    }
 
-         - Parameter secretKey: The secret key.
-         - Parameter header: The header.
+    /**
+     Starts reading a stream, whose header is `header`.
 
-         - Returns: The stream to decrypt messages from.
-         */
-        public func initPull(secretKey: Key, header: Header) -> PullStream? {
-            return PullStream(secretKey: secretKey, header: header)
-        }
+     - Parameter secretKey: The secret key.
+     - Parameter header: The header.
 
-        public class PushStream: StateStream {
-            typealias State = crypto_secretstream_xchacha20poly1305_state
+     - Returns: The stream to decrypt messages from.
+     */
+    public func initPull(secretKey: Key, header: Header) -> PullStream? {
+        return PullStream(secretKey: secretKey, header: header)
+    }
+}
 
-            static let capacity = crypto_secretstream_xchacha20poly1305_statebytes()
-            private var state: UnsafeMutablePointer<State>
+extension SecretStream.XChaCha20Poly1305 {
+    public class PushStream {
+        private var state: UnsafeMutablePointer<State>
+        private var _header: Header
 
-            private var _header: Header
+        init?(secretKey: Key) {
+            guard secretKey.count == KeyBytes else { return nil }
 
-            init?(secretKey: Key) {
-                guard secretKey.count == KeyBytes else { return nil }
-
-                state = PushStream.generate()
-                _header = Bytes(count: HeaderBytes)
-                guard .SUCCESS == crypto_secretstream_xchacha20poly1305_init_push(
-                    state,
-                    &_header,
-                    secretKey
-                ).exitCode else {
-                    free()
-                    return nil
-                }
-            }
-
-            /**
-             The header of the stream, required to decrypt it.
-
-             - Returns: The stream header.
-             */
-            public func header() -> Header {
-                return _header
-            }
-
-            /**
-             Encrypts and authenticate a new message. Optionally also authenticate `ad`.
-
-             - Parameter message: The message to encrypt.
-             - Parameter tag: The tag to attach to the message. By default `.MESSAGE`.
-             You may want to use `.FINAL` for the last message of the stream instead.
-             - Parameter ad: Optional additional data to authenticate.
-
-             - Returns: The ciphertext.
-             */
-            public func push(message: Bytes, tag: Tag = .MESSAGE, ad: Bytes? = nil) -> Bytes? {
-                let _ad = ad ?? Bytes(count: 0)
-                var cipherText = Bytes(count: message.count + ABytes)
-                guard .SUCCESS == crypto_secretstream_xchacha20poly1305_push(
-                    state,
-                    &cipherText,
-                    nil,
-                    message, UInt64(message.count),
-                    _ad, UInt64(_ad.count),
-                    tag.rawValue
-                ).exitCode else { return nil }
-
-                return cipherText
-            }
-
-            /**
-             Performs an explicit key rotation.
-             */
-            public func rekey() {
-                crypto_secretstream_xchacha20poly1305_rekey(state)
-            }
-
-            private func free() {
-                PushStream.free(state)
-            }
-
-            deinit {
+            state = PushStream.generate()
+            _header = Bytes(count: HeaderBytes)
+            guard .SUCCESS == crypto_secretstream_xchacha20poly1305_init_push(
+                state,
+                &_header,
+                secretKey
+            ).exitCode else {
                 free()
+                return nil
             }
         }
 
-        public class PullStream: StateStream {
-            typealias State = crypto_secretstream_xchacha20poly1305_state
+        deinit {
+            free()
+        }
+    }
+}
 
-            static let capacity = crypto_secretstream_xchacha20poly1305_statebytes()
-            private var state: UnsafeMutablePointer<State>
+extension SecretStream.XChaCha20Poly1305.PushStream: StateStream {
+    typealias State = crypto_secretstream_xchacha20poly1305_state
+    static let capacity = crypto_secretstream_xchacha20poly1305_statebytes()
+}
 
-            init?(secretKey: Key, header: Header) {
-                guard header.count == HeaderBytes, secretKey.count == KeyBytes else {
-                    return nil
-                }
-                state = PushStream.generate()
-                guard .SUCCESS == crypto_secretstream_xchacha20poly1305_init_pull(
-                    state,
-                    header,
-                    secretKey
-                ).exitCode else {
-                    free()
-                    return nil
-                }
+extension SecretStream.XChaCha20Poly1305.PushStream {
+    public typealias Header = SecretStream.XChaCha20Poly1305.Header
+
+    /**
+     The header of the stream, required to decrypt it.
+
+     - Returns: The stream header.
+     */
+    public func header() -> Header {
+        return _header
+    }
+}
+
+extension SecretStream.XChaCha20Poly1305.PushStream {
+    public typealias Tag = SecretStream.XChaCha20Poly1305.Tag
+    typealias XChaCha20Poly1305 = SecretStream.XChaCha20Poly1305
+
+    /**
+     Encrypts and authenticate a new message. Optionally also authenticate `ad`.
+
+     - Parameter message: The message to encrypt.
+     - Parameter tag: The tag to attach to the message. By default `.MESSAGE`.
+     You may want to use `.FINAL` for the last message of the stream instead.
+     - Parameter ad: Optional additional data to authenticate.
+
+     - Returns: The ciphertext.
+     */
+    public func push(message: Bytes, tag: Tag = .MESSAGE, ad: Bytes? = nil) -> Bytes? {
+        let _ad = ad ?? Bytes(count: 0)
+        var cipherText = Bytes(count: message.count + XChaCha20Poly1305.ABytes)
+        guard .SUCCESS == crypto_secretstream_xchacha20poly1305_push(
+            state,
+            &cipherText,
+            nil,
+            message, UInt64(message.count),
+            _ad, UInt64(_ad.count),
+            tag.rawValue
+        ).exitCode else { return nil }
+
+        return cipherText
+    }
+
+    /**
+     Performs an explicit key rotation.
+     */
+    public func rekey() {
+        crypto_secretstream_xchacha20poly1305_rekey(state)
+    }
+}
+
+extension SecretStream.XChaCha20Poly1305.PushStream {
+    private func free() {
+        XChaCha20Poly1305.PushStream.free(state)
+    }
+}
+
+extension SecretStream.XChaCha20Poly1305 {
+    public class PullStream: StateStream {
+        typealias State = crypto_secretstream_xchacha20poly1305_state
+
+        static let capacity = crypto_secretstream_xchacha20poly1305_statebytes()
+        private var state: UnsafeMutablePointer<State>
+
+        init?(secretKey: Key, header: Header) {
+            guard header.count == HeaderBytes, secretKey.count == KeyBytes else {
+                return nil
             }
-
-            /**
-             Decrypts a new message off the stream.
-
-             - Parameter cipherText: The encrypted message.
-             - Parameter ad: Optional additional data to authenticate.
-
-             - Returns: The decrypted message, as well as the tag attached to it.
-             */
-            public func pull(cipherText: Bytes, ad: Bytes? = nil) -> (Bytes, Tag)? {
-                guard cipherText.count >= ABytes else { return nil }
-                var message = Bytes(count: cipherText.count - ABytes)
-                let _ad = ad ?? Bytes(count: 0)
-                var _tag: UInt8 = 0
-                let result = crypto_secretstream_xchacha20poly1305_pull(
-                    state,
-                    &message,
-                    nil,
-                    &_tag,
-                    cipherText, UInt64(cipherText.count),
-                    _ad, UInt64(_ad.count)
-                ).exitCode
-
-                guard result == .SUCCESS, let tag = Tag(rawValue: _tag) else {
-                    return nil
-                }
-                return (message, tag)
-            }
-
-            /**
-             Performs an explicit key rotation.
-             */
-            public func rekey() {
-                crypto_secretstream_xchacha20poly1305_rekey(state)
-            }
-
-            private func free() {
-                PullStream.free(state)
-            }
-
-            deinit {
+            state = PushStream.generate()
+            guard .SUCCESS == crypto_secretstream_xchacha20poly1305_init_pull(
+                state,
+                header,
+                secretKey
+            ).exitCode else {
                 free()
+                return nil
             }
         }
+
+        deinit {
+            free()
+        }
+    }
+}
+
+extension SecretStream.XChaCha20Poly1305.PullStream {
+    public typealias Tag = SecretStream.XChaCha20Poly1305.Tag
+    typealias XChaCha20Poly1305 = SecretStream.XChaCha20Poly1305
+
+    /**
+     Decrypts a new message off the stream.
+
+     - Parameter cipherText: The encrypted message.
+     - Parameter ad: Optional additional data to authenticate.
+
+     - Returns: The decrypted message, as well as the tag attached to it.
+     */
+    public func pull(cipherText: Bytes, ad: Bytes? = nil) -> (Bytes, Tag)? {
+        guard cipherText.count >= ABytes else { return nil }
+        var message = Bytes(count: cipherText.count - XChaCha20Poly1305.ABytes)
+        let _ad = ad ?? Bytes(count: 0)
+        var _tag: UInt8 = 0
+        let result = crypto_secretstream_xchacha20poly1305_pull(
+            state,
+            &message,
+            nil,
+            &_tag,
+            cipherText, UInt64(cipherText.count),
+            _ad, UInt64(_ad.count)
+        ).exitCode
+
+        guard result == .SUCCESS, let tag = Tag(rawValue: _tag) else {
+            return nil
+        }
+        return (message, tag)
+    }
+
+    /**
+     Performs an explicit key rotation.
+     */
+    public func rekey() {
+        crypto_secretstream_xchacha20poly1305_rekey(state)
+    }
+}
+
+extension SecretStream.XChaCha20Poly1305.PullStream {
+    private func free() {
+        XChaCha20Poly1305.PullStream.free(state)
     }
 }
 

--- a/Sodium/ShortHash.swift
+++ b/Sodium/ShortHash.swift
@@ -3,7 +3,9 @@ import Clibsodium
 
 public struct ShortHash {
     public let Bytes = Int(crypto_shorthash_bytes())
+}
 
+extension ShortHash {
     /**
      Computes short but unpredictable (without knowing the secret key) values suitable for picking a list in a hash table for a given key.
 

--- a/Sodium/ShortHash.swift
+++ b/Sodium/ShortHash.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class ShortHash {
+public struct ShortHash {
     public let Bytes = Int(crypto_shorthash_bytes())
 
     /**

--- a/Sodium/ShortHash.swift
+++ b/Sodium/ShortHash.swift
@@ -14,7 +14,8 @@ extension ShortHash {
 
      - Returns: The computed fingerprint.
      */
-    public func hash(message: Bytes, key: Bytes) -> Bytes? {
+    public func hash(message: BytesRepresentable, key: BytesRepresentable) -> Bytes? {
+        let (message, key) = (message.bytes, key.bytes)
         guard key.count == KeyBytes else { return nil }
         var output = Array<UInt8>(count: Bytes)
 

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class Sign {
+public struct Sign {
     public let Bytes = Int(crypto_sign_bytes())
     public let Primitive = String(validatingUTF8: crypto_sign_primitive())
 

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -15,7 +15,8 @@ extension Sign {
 
      - Returns: The signed message.
      */
-    public func sign(message: Bytes, secretKey: SecretKey) -> Bytes? {
+    public func sign(message: BytesRepresentable, secretKey: SecretKey) -> Bytes? {
+        let message = message.bytes
         guard secretKey.count == SecretKeyBytes else { return nil }
         var signedMessage = Array<UInt8>(count: message.count + Bytes)
 
@@ -37,10 +38,11 @@ extension Sign {
 
      - Returns: The computed signature.
      */
-    public func signature(message: Bytes, secretKey: SecretKey) -> Bytes? {
+    public func signature(message: BytesRepresentable, secretKey: SecretKey) -> Bytes? {
         guard secretKey.count == SecretKeyBytes else { return nil }
         var signature = Array<UInt8>(count: Bytes)
 
+        let message = message.bytes
         guard .SUCCESS == crypto_sign_detached (
             &signature,
             nil,
@@ -61,7 +63,8 @@ extension Sign {
 
      - Returns: `true` if verification is successful.
      */
-    public func verify(signedMessage: Bytes, publicKey: PublicKey) -> Bool {
+    public func verify(signedMessage: BytesRepresentable, publicKey: PublicKey) -> Bool {
+        let signedMessage = signedMessage.bytes
         let signature = signedMessage[..<Bytes].bytes
         let message = signedMessage[Bytes...].bytes
 
@@ -77,11 +80,12 @@ extension Sign {
 
      - Returns: `true` if verification is successful.
      */
-    public func verify(message: Bytes, publicKey: PublicKey, signature: Bytes) -> Bool {
+    public func verify(message: BytesRepresentable, publicKey: PublicKey, signature: Bytes) -> Bool {
         guard publicKey.count == PublicKeyBytes else {
             return false
         }
 
+        let message = message.bytes
         return .SUCCESS == crypto_sign_verify_detached (
             signature,
             message, UInt64(message.count),
@@ -99,7 +103,8 @@ extension Sign {
 
      - Returns: The message data if verification is successful.
      */
-    public func open(signedMessage: Bytes, publicKey: PublicKey) -> Bytes? {
+    public func open(signedMessage: BytesRepresentable, publicKey: PublicKey) -> Bytes? {
+        let signedMessage = signedMessage.bytes
         guard publicKey.count == PublicKeyBytes, signedMessage.count >= Bytes else {
             return nil
         }

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -4,7 +4,9 @@ import Clibsodium
 public struct Sign {
     public let Bytes = Int(crypto_sign_bytes())
     public let Primitive = String(validatingUTF8: crypto_sign_primitive())
+}
 
+extension Sign {
     /**
      Signs a message with the sender's secret key
 
@@ -48,7 +50,9 @@ public struct Sign {
 
         return signature
     }
+}
 
+extension Sign {
     /**
      Verifies a signed message with the sender's public key.
 
@@ -84,7 +88,9 @@ public struct Sign {
             publicKey
         ).exitCode
     }
+}
 
+extension Sign {
     /**
      Extracts and returns the message data of a signed message if the signature is verified with the sender's secret key.
 

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -17,13 +17,15 @@ public struct Sodium {
     public let secretStream = SecretStream()
     public let aead = Aead()
 
+    public init() {
+        _ = Sodium.once
+    }
+}
+
+extension Sodium {
     private static let once: Void = {
         guard sodium_init() >= 0 else {
             fatalError("Failed to initialize libsodium")
         }
     }()
-
-    public init() {
-        _ = Sodium.once
-    }
 }

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class Sodium {
+public struct Sodium {
     public let box = Box()
     public let secretBox = SecretBox()
     public let genericHash = GenericHash()

--- a/Sodium/StateStream.swift
+++ b/Sodium/StateStream.swift
@@ -3,27 +3,3 @@ protocol StateStream {
 
     static var capacity: Int { get }
 }
-
-extension StateStream {
-    static func free(_ state: UnsafeMutablePointer<State>) {
-        let rawState = UnsafeMutableRawPointer(state).bindMemory(
-            to: UInt8.self,
-            capacity: capacity
-        )
-
-        #if swift(>=4.1)
-        rawState.deallocate()
-        #else
-        rawState.deallocate(capacity: 1)
-        #endif
-    }
-
-    static func generate() -> UnsafeMutablePointer<State> {
-        let rawState = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
-
-        return UnsafeMutableRawPointer(rawState).bindMemory(
-            to: State.self,
-            capacity: 1
-        )
-    }
-}

--- a/Sodium/Stream.swift
+++ b/Sodium/Stream.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class Stream {
+public struct Stream {
     public let Primitive = String(validatingUTF8: crypto_stream_primitive())
 
     /**

--- a/Sodium/Stream.swift
+++ b/Sodium/Stream.swift
@@ -3,7 +3,9 @@ import Clibsodium
 
 public struct Stream {
     public let Primitive = String(validatingUTF8: crypto_stream_primitive())
+}
 
+extension Stream {
     /**
      XOR the input with a key stream derived from a secret key and a nonce.
      Applying the same operation twice outputs the original input.

--- a/Sodium/Stream.swift
+++ b/Sodium/Stream.swift
@@ -19,9 +19,10 @@ extension Stream {
 
      -  Returns: input XOR keystream(secretKey, nonce)
      */
-    public func xor(input: Bytes, nonce: Nonce, secretKey: Key) -> Bytes? {
+    public func xor(input: BytesRepresentable, nonce: Nonce, secretKey: Key) -> Bytes? {
         guard secretKey.count == KeyBytes, nonce.count == NonceBytes else { return nil }
 
+        let input = input.bytes
         var output = Bytes(count: input.count)
         guard .SUCCESS == crypto_stream_xor (
             &output,
@@ -46,9 +47,10 @@ extension Stream {
 
      -  Returns: (input XOR keystream(secretKey, nonce), nonce)
      */
-    public func xor(input: Bytes, secretKey: Key) -> (output:Bytes, nonce: Nonce)? {
+    public func xor(input: BytesRepresentable, secretKey: Key) -> (output:Bytes, nonce: Nonce)? {
         let nonce = self.nonce()
 
+        let input = input.bytes
         guard let output: Bytes = xor(
             input: input,
             nonce: nonce,

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -11,6 +11,9 @@ public struct Utils {
         let count = data.count
         sodium_memzero(&data, count)
     }
+}
+
+extension Utils {
 
     /**
      Checks that two `Bytes` objects have the same content, without leaking information
@@ -39,7 +42,9 @@ public struct Utils {
         guard b1.count == b2.count else { return nil }
         return Int(sodium_compare(b1, b2, b1.count))
     }
+}
 
+extension Utils {
     /**
      Converts bytes stored in `bin` into a hexadecimal string.
 
@@ -85,14 +90,18 @@ public struct Utils {
 
         return binBytes
     }
+}
 
+extension Utils {
     public enum Base64Variant: CInt {
         case ORIGINAL            = 1
         case ORIGINAL_NO_PADDING = 3
         case URLSAFE             = 5
         case URLSAFE_NO_PADDING  = 7
     }
+}
 
+extension Utils {
     /**
      Converts bytes stored in `bin` into a Base64 representation.
 
@@ -140,7 +149,9 @@ public struct Utils {
 
         return binBytes
     }
+}
 
+extension Utils {
     /*
      Adds padding to `data` so that its length becomes a multiple of `blockSize`
 

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public class Utils {
+public struct Utils {
     /**
      Tries to effectively zero bytes in `data`, even if optimizations are being applied to the code.
 

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -1,7 +1,18 @@
 import Foundation
 import Clibsodium
 
-public struct Utils {
+public struct Utils {}
+
+extension Utils {
+    public enum Base64Variant: CInt {
+        case ORIGINAL            = 1
+        case ORIGINAL_NO_PADDING = 3
+        case URLSAFE             = 5
+        case URLSAFE_NO_PADDING  = 7
+    }
+}
+
+extension Utils {
     /**
      Tries to effectively zero bytes in `data`, even if optimizations are being applied to the code.
 
@@ -89,15 +100,6 @@ extension Utils {
         binBytes = binBytes[..<binBytesLen].bytes
 
         return binBytes
-    }
-}
-
-extension Utils {
-    public enum Base64Variant: CInt {
-        case ORIGINAL            = 1
-        case ORIGINAL_NO_PADDING = 3
-        case URLSAFE             = 5
-        case URLSAFE_NO_PADDING  = 7
     }
 }
 

--- a/Tests/SodiumTests/ReadmeTests.swift
+++ b/Tests/SodiumTests/ReadmeTests.swift
@@ -31,7 +31,7 @@ class ReadmeTests : XCTestCase {
         let sodium = Sodium()
         let aliceKeyPair = sodium.box.keyPair()!
         let bobKeyPair = sodium.box.keyPair()!
-        let message = "My Test Message".bytes
+        let message = "My Test Message"
 
         let encryptedMessageFromAliceToBob: Bytes =
             sodium.box.seal(message: message,
@@ -49,7 +49,7 @@ class ReadmeTests : XCTestCase {
     func testAnonymousEncryptionSealedBoxes() {
         let sodium = Sodium()
         let bobKeyPair = sodium.box.keyPair()!
-        let message = "My Test Message".bytes
+        let message = "My Test Message"
 
         let encryptedMessageToBob =
             sodium.box.seal(message: message, recipientPublicKey: bobKeyPair.publicKey)!
@@ -81,7 +81,7 @@ class ReadmeTests : XCTestCase {
 
     func testDetachedSignatures() {
         let sodium = Sodium()
-        let message = "My Test Message".bytes
+        let message = "My Test Message"
         let keyPair = sodium.sign.keyPair()!
         let signature = sodium.sign.signature(message: message, secretKey: keyPair.secretKey)!
         if sodium.sign.verify(message: message,
@@ -93,7 +93,7 @@ class ReadmeTests : XCTestCase {
 
     func testAttachedSignatures() {
         let sodium = Sodium()
-        let message = "My Test Message".bytes
+        let message = "My Test Message"
         let keyPair = sodium.sign.keyPair()!
         let signedMessage = sodium.sign.sign(message: message, secretKey: keyPair.secretKey)!
         if sodium.sign.open(signedMessage: signedMessage, publicKey: keyPair.publicKey) != nil {
@@ -103,7 +103,7 @@ class ReadmeTests : XCTestCase {
 
     func testSecretKeyAuthenticatedEncryption() {
         let sodium = Sodium()
-        let message = "My Test Message".bytes
+        let message = "My Test Message"
         let secretKey = sodium.secretBox.key()
         let encrypted: Bytes = sodium.secretBox.seal(message: message, secretKey: secretKey)!
         if sodium.secretBox.open(nonceAndAuthenticatedCipherText: encrypted, secretKey: secretKey) != nil {
@@ -113,7 +113,7 @@ class ReadmeTests : XCTestCase {
 
     func testDeterministicHashing() {
         let sodium = Sodium()
-        let message = "My Test Message".bytes
+        let message = "My Test Message"
         let h = sodium.genericHash.hash(message: message)
 
         XCTAssertNotNil(h)
@@ -121,8 +121,8 @@ class ReadmeTests : XCTestCase {
 
     func testKeyedHashing() {
         let sodium = Sodium()
-        let message = "My Test Message".bytes
-        let key = "Secret key".bytes
+        let message = "My Test Message"
+        let key = "Secret key"
         let h = sodium.genericHash.hash(message: message, key: key)
 
         XCTAssertNotNil(h)
@@ -130,9 +130,9 @@ class ReadmeTests : XCTestCase {
 
     func testStreaming() {
         let sodium = Sodium()
-        let message1 = "My Test ".bytes
-        let message2 = "Message".bytes
-        let key = "Secret key".bytes
+        let message1 = "My Test "
+        let message2 = "Message"
+        let key = "Secret key"
         var stream = sodium.genericHash.initStream(key: key)!
         stream.update(input: message1)
         stream.update(input: message2)
@@ -143,7 +143,7 @@ class ReadmeTests : XCTestCase {
 
     func testShortOutputHashing() {
         let sodium = Sodium()
-        let message = "My Test Message".bytes
+        let message = "My Test Message"
         let key = sodium.randomBytes.buf(length: sodium.shortHash.KeyBytes)!
         let h = sodium.shortHash.hash(message: message, key: key)
 
@@ -159,7 +159,7 @@ class ReadmeTests : XCTestCase {
 
     func testPasswordHashing() {
         let sodium = Sodium()
-        let password = "Correct Horse Battery Staple".bytes
+        let password = "Correct Horse Battery Staple"
         let hashedStr = sodium.pwHash.str(passwd: password,
                                           opsLimit: sodium.pwHash.OpsLimitInteractive,
                                           memLimit: sodium.pwHash.MemLimitInteractive)!
@@ -212,17 +212,17 @@ class ReadmeTests : XCTestCase {
 
     func testStream() {
         let sodium = Sodium()
-        let input = "test".bytes
+        let input = "test"
         let key = sodium.stream.key()
         let (output, nonce) = sodium.stream.xor(input: input, secretKey: key)!
         let twice = sodium.stream.xor(input: output, nonce: nonce, secretKey: key)!
 
-        XCTAssertEqual(input, twice)
+        XCTAssertEqual(input.bytes, twice)
     }
 
     func testAuth() {
         let sodium = Sodium()
-        let input = "test".bytes
+        let input = "test"
         let key = sodium.auth.key()
         let tag = sodium.auth.tag(message: input, secretKey: key)!
         let tagIsValid = sodium.auth.verify(message: input, secretKey: key, tag: tag)
@@ -245,9 +245,9 @@ class ReadmeTests : XCTestCase {
 
     func testSecretStream() {
         let sodium = Sodium()
-        let message1 = "Message 1".bytes
-        let message2 = "Message 2".bytes
-        let message3 = "Message 3".bytes
+        let message1 = "Message 1"
+        let message2 = "Message 2"
+        let message3 = "Message 3"
 
         let secretkey = sodium.secretStream.xchacha20poly1305.key()
 
@@ -266,9 +266,9 @@ class ReadmeTests : XCTestCase {
         let (message2_dec, tag2) = stream_dec.pull(cipherText: encrypted2)!
         let (message3_dec, tag3) = stream_dec.pull(cipherText: encrypted3)!
 
-        XCTAssertEqual(message1, message1_dec)
-        XCTAssertEqual(message2, message2_dec)
-        XCTAssertEqual(message3, message3_dec)
+        XCTAssertEqual(message1.bytes, message1_dec)
+        XCTAssertEqual(message2.bytes, message2_dec)
+        XCTAssertEqual(message3.bytes, message3_dec)
         XCTAssertEqual(tag1, .MESSAGE)
         XCTAssertEqual(tag2, .MESSAGE)
         XCTAssertEqual(tag3, .FINAL)

--- a/Tests/SodiumTests/ReadmeTests.swift
+++ b/Tests/SodiumTests/ReadmeTests.swift
@@ -133,9 +133,9 @@ class ReadmeTests : XCTestCase {
         let message1 = "My Test ".bytes
         let message2 = "Message".bytes
         let key = "Secret key".bytes
-        let stream = sodium.genericHash.initStream(key: key)!
-        let _ = stream.update(input: message1)
-        let _ = stream.update(input: message2)
+        var stream = sodium.genericHash.initStream(key: key)!
+        stream.update(input: message1)
+        stream.update(input: message2)
         let h = stream.final()
 
         XCTAssertNotNil(h)
@@ -253,7 +253,7 @@ class ReadmeTests : XCTestCase {
 
         /* stream encryption */
 
-        let stream_enc = sodium.secretStream.xchacha20poly1305.initPush(secretKey: secretkey)!
+        var stream_enc = sodium.secretStream.xchacha20poly1305.initPush(secretKey: secretkey)!
         let header = stream_enc.header()
         let encrypted1 = stream_enc.push(message: message1)!
         let encrypted2 = stream_enc.push(message: message2)!
@@ -261,7 +261,7 @@ class ReadmeTests : XCTestCase {
 
         /* stream decryption */
 
-        let stream_dec = sodium.secretStream.xchacha20poly1305.initPull(secretKey: secretkey, header: header)!
+        var stream_dec = sodium.secretStream.xchacha20poly1305.initPull(secretKey: secretkey, header: header)!
         let (message1_dec, tag1) = stream_dec.pull(cipherText: encrypted1)!
         let (message2_dec, tag2) = stream_dec.pull(cipherText: encrypted2)!
         let (message3_dec, tag3) = stream_dec.pull(cipherText: encrypted3)!

--- a/Tests/SodiumTests/SodiumTests.swift
+++ b/Tests/SodiumTests/SodiumTests.swift
@@ -133,17 +133,17 @@ class SodiumTests: XCTestCase {
         let h3 = sodium.utils.bin2hex(sodium.genericHash.hash(message: message, key: key, outputLength: sodium.genericHash.BytesMax)!)!
         XCTAssertEqual(h3, "cba85e39f2d03923b2f66aba99b204333edc34a8443ab1700f7920c7abcc6639963a953f35162a520b21072ab906457d21f1645e6e3985858ee95a84d0771f07")
 
-        let s1 = sodium.genericHash.initStream()!
+        var s1 = sodium.genericHash.initStream()!
         XCTAssertTrue(s1.update(input: message))
         let h4 = sodium.utils.bin2hex(s1.final()!)!
         XCTAssertEqual(h4, h1)
 
-        let s2 = sodium.genericHash.initStream(key: key, outputLength: sodium.genericHash.Bytes)!
+        var s2 = sodium.genericHash.initStream(key: key, outputLength: sodium.genericHash.Bytes)!
         XCTAssertTrue(s2.update(input: message))
         let h5 = sodium.utils.bin2hex(s2.final()!)!
         XCTAssertEqual(h5, h2)
 
-        let s3 = sodium.genericHash.initStream(key: key, outputLength: sodium.genericHash.BytesMax)!
+        var s3 = sodium.genericHash.initStream(key: key, outputLength: sodium.genericHash.BytesMax)!
         XCTAssertTrue(s3.update(input: message))
         let h6 = sodium.utils.bin2hex(s3.final()!)!
         XCTAssertEqual(h6, h3)
@@ -340,13 +340,13 @@ class SodiumTests: XCTestCase {
         let secretKey = sodium.secretStream.xchacha20poly1305.key()
         XCTAssertEqual(secretKey.count, 32)
 
-        let stream = sodium.secretStream.xchacha20poly1305.initPush(secretKey: secretKey)!
+        var stream = sodium.secretStream.xchacha20poly1305.initPush(secretKey: secretKey)!
         let header = stream.header()
         let encrypted1 = stream.push(message: "message 1".bytes)!
         let encrypted2 = stream.push(message: "message 2".bytes)!
         let encrypted3 = stream.push(message: "message 3".bytes, tag: .FINAL)!
 
-        let stream2 = sodium.secretStream.xchacha20poly1305.initPull(secretKey: secretKey, header: header)!
+        var stream2 = sodium.secretStream.xchacha20poly1305.initPull(secretKey: secretKey, header: header)!
         let (message1, tag1) = stream2.pull(cipherText: encrypted1)!
         let (message2, tag2) = stream2.pull(cipherText: encrypted2)!
         let (message3, tag3) = stream2.pull(cipherText: encrypted3)!


### PR DESCRIPTION
Recall #144 changed some functions to accept `Bytes` instead of `Data`.

This PR introduces a `BytesRepresentable` protocol that types can implement to specify how they should be converted to bytes and constructed from bytes. This protocol requires the conforming type to always succeed in converting to `Bytes`, but allows for the possibility of failure the other way round.

Any conforming type will also receive a default implementation for constructing itself from an arbitrary `BytesRepresentable`.

Included also are conformance implementations for `String` `[UInt8]` (`Bytes`), `ArraySlice<UInt8>`, and `Data`.

This means that

```swift
let encryptedMessageToBob =
    sodium.box.seal(message: message, recipientPublicKey: bobKeyPair.publicKey)!
```

is valid code when `message` is any of `String`, `Bytes`, `Data`, or any other `BytesRepresentable`.

---

This is based on #148, so the commits relevant only to this PR begin at 0ee6d72 ([actual diff](https://github.com/aidantwoods/swift-sodium/compare/enhancement/remove-stream-pointers...aidantwoods:enhancement/bytes-representable-protocol))