### PR TITLE
Make KeyPairGenerator and KeyPairProtocol and related public

### DIFF
--- a/Sodium/Aead.swift
+++ b/Sodium/Aead.swift
@@ -108,5 +108,5 @@ extension Aead.XChaCha20Poly1305Ietf: SecretKeyGenerator {
     public var KeyBytes: Int { return Int(crypto_aead_xchacha20poly1305_ietf_keybytes()) }
     public typealias Key = Bytes
 
-    static var keygen: (UnsafeMutablePointer<UInt8>) -> Void = crypto_aead_xchacha20poly1305_ietf_keygen
+    public static var keygen: (UnsafeMutablePointer<UInt8>) -> Void = crypto_aead_xchacha20poly1305_ietf_keygen
 }

--- a/Sodium/Auth.swift
+++ b/Sodium/Auth.swift
@@ -51,5 +51,5 @@ extension Auth: SecretKeyGenerator {
     public var KeyBytes: Int { return Int(crypto_auth_keybytes()) }
     public typealias Key = Bytes
 
-    static let keygen: (_ k: UnsafeMutablePointer<UInt8>) -> Void = crypto_auth_keygen
+    public static let keygen: (_ k: UnsafeMutablePointer<UInt8>) -> Void = crypto_auth_keygen
 }

--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -357,12 +357,12 @@ extension Box: KeyPairGenerator {
     public var PublicKeyBytes: Int { return Int(crypto_box_publickeybytes()) }
     public var SecretKeyBytes: Int { return Int(crypto_box_secretkeybytes()) }
 
-    static let newKeypair: (
+    public static let newKeypair: (
         _ pk: UnsafeMutablePointer<UInt8>,
         _ sk: UnsafeMutablePointer<UInt8>
     ) -> Int32 = crypto_box_keypair
 
-    static let keypairFromSeed: (
+    public static let keypairFromSeed: (
         _ pk: UnsafeMutablePointer<UInt8>,
         _ sk: UnsafeMutablePointer<UInt8>,
         _ seed: UnsafePointer<UInt8>
@@ -373,6 +373,11 @@ extension Box: KeyPairGenerator {
         public typealias SecretKey = Box.SecretKey
         public let publicKey: PublicKey
         public let secretKey: SecretKey
+
+        public init(publicKey: PublicKey, secretKey: SecretKey) {
+            self.publicKey = publicKey
+            self.secretKey = secretKey
+        }
     }
 }
 

--- a/Sodium/Generators/KeyPairGenerator.swift
+++ b/Sodium/Generators/KeyPairGenerator.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol KeyPairGenerator {
+public protocol KeyPairGenerator {
     associatedtype KeyPair: KeyPairProtocol
 
     var PublicKeyBytes: Int { get }

--- a/Sodium/Generators/KeyPairProtocol.swift
+++ b/Sodium/Generators/KeyPairProtocol.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol KeyPairProtocol {
+public protocol KeyPairProtocol {
     associatedtype PublicKey where PublicKey == Bytes
     associatedtype SecretKey where SecretKey == Bytes
     var publicKey: PublicKey { get }

--- a/Sodium/Generators/NonceGenerator.swift
+++ b/Sodium/Generators/NonceGenerator.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-protocol NonceGenerator {
+public protocol NonceGenerator {
     var NonceBytes: Int { get }
     associatedtype Nonce where Nonce == Bytes
 }

--- a/Sodium/Generators/SecretKeyGenerator.swift
+++ b/Sodium/Generators/SecretKeyGenerator.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol SecretKeyGenerator {
+public protocol SecretKeyGenerator {
     var KeyBytes: Int { get }
     associatedtype Key where Key == Bytes
 

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -155,6 +155,6 @@ extension GenericHash: SecretKeyGenerator {
     public var KeyBytes: Int { return Int(crypto_generichash_keybytes()) }
     public typealias Key = Bytes
 
-    static var keygen: (UnsafeMutablePointer<UInt8>) -> Void = crypto_generichash_keygen
+    public static var keygen: (UnsafeMutablePointer<UInt8>) -> Void = crypto_generichash_keygen
 
 }

--- a/Sodium/KeyDerivation.swift
+++ b/Sodium/KeyDerivation.swift
@@ -49,5 +49,5 @@ extension KeyDerivation: SecretKeyGenerator {
     public var KeyBytes: Int { return Int(crypto_kdf_keybytes()) }
     public typealias Key = Bytes
 
-    static var keygen: (UnsafeMutablePointer<UInt8>) -> Void = crypto_kdf_keygen
+    public static var keygen: (UnsafeMutablePointer<UInt8>) -> Void = crypto_kdf_keygen
 }

--- a/Sodium/KeyExchange.swift
+++ b/Sodium/KeyExchange.swift
@@ -74,12 +74,12 @@ extension KeyExchange: KeyPairGenerator {
     public var PublicKeyBytes: Int { return Int(crypto_kx_publickeybytes()) }
     public var SecretKeyBytes: Int { return Int(crypto_kx_secretkeybytes()) }
 
-    static let newKeypair: (
+    public static let newKeypair: (
         _ pk: UnsafeMutablePointer<UInt8>,
         _ sk: UnsafeMutablePointer<UInt8>
     ) -> Int32 = crypto_kx_keypair
 
-    static let keypairFromSeed: (
+    public static let keypairFromSeed: (
         _ pk: UnsafeMutablePointer<UInt8>,
         _ sk: UnsafeMutablePointer<UInt8>,
         _ seed: UnsafePointer<UInt8>
@@ -90,5 +90,10 @@ extension KeyExchange: KeyPairGenerator {
         public typealias SecretKey = KeyExchange.SecretKey
         public let publicKey: PublicKey
         public let secretKey: SecretKey
+
+        public init(publicKey: PublicKey, secretKey: SecretKey) {
+            self.publicKey = publicKey
+            self.secretKey = secretKey
+        }
     }
 }

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -147,5 +147,5 @@ extension SecretBox: SecretKeyGenerator {
     public typealias Key = Bytes
     public var KeyBytes: Int { return Int(crypto_secretbox_keybytes()) }
 
-    static let keygen: (_ k: UnsafeMutablePointer<UInt8>) -> Void = crypto_secretbox_keygen
+    public static let keygen: (_ k: UnsafeMutablePointer<UInt8>) -> Void = crypto_secretbox_keygen
 }

--- a/Sodium/SecretStream.swift
+++ b/Sodium/SecretStream.swift
@@ -181,9 +181,8 @@ public class SecretStream {
 }
 
 extension SecretStream.XChaCha20Poly1305: SecretKeyGenerator {
-    var KeyBytes: Int { return SecretStream.XChaCha20Poly1305.KeyBytes }
+    public var KeyBytes: Int { return SecretStream.XChaCha20Poly1305.KeyBytes }
     public typealias Key = Bytes
 
-    static var keygen: (UnsafeMutablePointer<UInt8>) -> Void = crypto_secretstream_xchacha20poly1305_keygen
-
+    public static var keygen: (UnsafeMutablePointer<UInt8>) -> Void = crypto_secretstream_xchacha20poly1305_keygen
 }

--- a/Sodium/ShortHash.swift
+++ b/Sodium/ShortHash.swift
@@ -30,5 +30,5 @@ extension ShortHash: SecretKeyGenerator {
     public var KeyBytes: Int { return Int(crypto_shorthash_keybytes()) }
     public typealias Key = Bytes
 
-    static var keygen: (UnsafeMutablePointer<UInt8>) -> Void = crypto_shorthash_keygen
+    public static var keygen: (UnsafeMutablePointer<UInt8>) -> Void = crypto_shorthash_keygen
 }

--- a/Sodium/Sign.swift
+++ b/Sodium/Sign.swift
@@ -119,12 +119,12 @@ extension Sign: KeyPairGenerator {
     public var PublicKeyBytes: Int { return Int(crypto_sign_publickeybytes()) }
     public var SecretKeyBytes: Int { return Int(crypto_sign_secretkeybytes()) }
 
-    static let newKeypair: (
+    public static let newKeypair: (
         _ pk: UnsafeMutablePointer<UInt8>,
         _ sk: UnsafeMutablePointer<UInt8>
     ) -> Int32 = crypto_sign_keypair
 
-    static let keypairFromSeed: (
+    public static let keypairFromSeed: (
         _ pk: UnsafeMutablePointer<UInt8>,
         _ sk: UnsafeMutablePointer<UInt8>,
         _ seed: UnsafePointer<UInt8>
@@ -135,5 +135,10 @@ extension Sign: KeyPairGenerator {
         public typealias SecretKey = Sign.SecretKey
         public let publicKey: PublicKey
         public let secretKey: SecretKey
+
+        public init(publicKey: PublicKey, secretKey: SecretKey) {
+            self.publicKey = publicKey
+            self.secretKey = secretKey
+        }
     }
 }

--- a/Sodium/Stream.swift
+++ b/Sodium/Stream.swift
@@ -66,5 +66,5 @@ extension Stream: SecretKeyGenerator {
     public typealias Key = Bytes
     public var KeyBytes: Int { return Int(crypto_secretbox_keybytes()) }
 
-    static let keygen: (_ k: UnsafeMutablePointer<UInt8>) -> Void = crypto_stream_keygen
+    public static let keygen: (_ k: UnsafeMutablePointer<UInt8>) -> Void = crypto_stream_keygen
 }


### PR DESCRIPTION
This is a quick stopgap to fix https://github.com/jedisct1/swift-sodium/issues/152 where dynamic linking of release builds fail because of Swift compiler issues around a public class conforming to an internal protocol.