### PR TITLE
Fix Swift 4.2 exclusive memory access errors

### DIFF
--- a/Sodium/Box.swift
+++ b/Sodium/Box.swift
@@ -80,8 +80,9 @@ public class Box {
      */
     public func nonce() -> Nonce {
         var nonce = Data(count: NonceBytes)
+        let nonceCount = nonce.count
         nonce.withUnsafeMutableBytes { noncePtr in
-            randombytes_buf(noncePtr, nonce.count)
+            randombytes_buf(noncePtr, nonceCount)
         }
         return nonce
     }

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -50,14 +50,18 @@ public class GenericHash {
         var output = Data(count: outputLength)
         var result: Int32 = -1
 
+        let outputCount = output.count
+        let messageCount = message.count
+
         if let key = key {
+            let keyCount = key.count
             result = output.withUnsafeMutableBytes { outputPtr in
                 message.withUnsafeBytes { messagePtr in
                     key.withUnsafeBytes { keyPtr in
                         crypto_generichash(
-                            outputPtr, output.count,
-                            messagePtr, CUnsignedLongLong(message.count),
-                            keyPtr, key.count)
+                            outputPtr, outputCount,
+                            messagePtr, CUnsignedLongLong(messageCount),
+                            keyPtr, keyCount)
                     }
                 }
             }
@@ -65,8 +69,8 @@ public class GenericHash {
             result = output.withUnsafeMutableBytes { outputPtr in
                 message.withUnsafeBytes { messagePtr in
                     crypto_generichash(
-                        outputPtr, output.count,
-                        messagePtr, CUnsignedLongLong(message.count),
+                        outputPtr, outputCount,
+                        messagePtr, CUnsignedLongLong(messageCount),
                         nil, 0)
                 }
             }
@@ -181,8 +185,9 @@ public class GenericHash {
          */
         public func final() -> Data? {
             var output = Data(count: outputLength)
+            let outputCount = output.count
             let result = output.withUnsafeMutableBytes { outputPtr in
-                crypto_generichash_final(state!, outputPtr, output.count)
+                crypto_generichash_final(state!, outputPtr, outputCount)
             }
             if result != 0 {
                 return nil

--- a/Sodium/RandomBytes.swift
+++ b/Sodium/RandomBytes.swift
@@ -16,8 +16,9 @@ public class RandomBytes {
             return nil
         }
         var output = Data(count: length)
+        let outputCount = output.count
         output.withUnsafeMutableBytes { outputPtr in
-            randombytes_buf(outputPtr, output.count)
+            randombytes_buf(outputPtr, outputCount)
         }
         return output
     }
@@ -53,9 +54,10 @@ public class RandomBytes {
             return nil
         }
         var output = Data(count: length)
+        let outputCount = output.count
         output.withUnsafeMutableBytes { outputPtr in
             seed.withUnsafeBytes { seedPtr in
-                randombytes_buf_deterministic(outputPtr, output.count, seedPtr)
+                randombytes_buf_deterministic(outputPtr, outputCount, seedPtr)
             }
         }
         return output

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -30,8 +30,9 @@ public class SecretBox {
      */
     public func nonce() -> Nonce {
         var nonce = Data(count: NonceBytes)
+        let nonceCount = nonce.count
         nonce.withUnsafeMutableBytes { noncePtr in
-            randombytes_buf(noncePtr, nonce.count)
+            randombytes_buf(noncePtr, nonceCount)
         }
         return nonce
     }

--- a/Sodium/Stream.swift
+++ b/Sodium/Stream.swift
@@ -29,8 +29,9 @@ public class Stream {
      */
     public func nonce() -> Nonce {
         var nonce = Data(count: NonceBytes)
+        let nonceCount = nonce.count
         nonce.withUnsafeMutableBytes { noncePtr in
-            randombytes_buf(noncePtr, nonce.count)
+            randombytes_buf(noncePtr, nonceCount)
         }
         return nonce
     }

--- a/Sodium/Utils.swift
+++ b/Sodium/Utils.swift
@@ -64,10 +64,11 @@ public class Utils {
      */
     public func bin2hex(_ bin: Data) -> String? {
         var hexData = Data(count: bin.count * 2 + 1)
-
+        let hexDataCount = hexData.count
+        let binCount = bin.count
         return hexData.withUnsafeMutableBytes { (hexPtr: UnsafeMutablePointer<Int8>) -> String? in
             bin.withUnsafeBytes { (binPtr: UnsafePointer<UInt8>) -> String? in
-                if sodium_bin2hex(hexPtr, hexData.count, binPtr, bin.count) == nil {
+                if sodium_bin2hex(hexPtr, hexDataCount, binPtr, binCount) == nil {
                     return nil
                 }
                 return String.init(validatingUTF8: hexPtr)
@@ -125,10 +126,12 @@ public class Utils {
      */
     public func bin2base64(_ bin: Data, variant: Base64Variant = .URLSAFE) -> String? {
         var b64Data = Data(count: sodium_base64_encoded_len(bin.count, variant.rawValue))
+        let b64DataCount = b64Data.count
+        let binCount = bin.count
 
         return b64Data.withUnsafeMutableBytes { (b64Ptr: UnsafeMutablePointer<Int8>) -> String? in
             bin.withUnsafeBytes { (binPtr: UnsafePointer<UInt8>) -> String? in
-                if sodium_bin2base64(b64Ptr, b64Data.count, binPtr, bin.count, variant.rawValue) == nil {
+                if sodium_bin2base64(b64Ptr, b64DataCount, binPtr, binCount, variant.rawValue) == nil {
                     return nil
                 }
                 return String.init(validatingUTF8: b64Ptr)
@@ -199,8 +202,9 @@ public class Utils {
      */
     public func unpad(data: inout Data, blockSize: Int) -> ()? {
         var unpaddedLen: size_t = 0
+        let dataCount = data.count
         let result = data.withUnsafeMutableBytes { dataPtr in
-            sodium_unpad(&unpaddedLen, dataPtr, data.count, blockSize)
+            sodium_unpad(&unpaddedLen, dataPtr, dataCount, blockSize)
         }
         if result != 0 {
             return nil


### PR DESCRIPTION
Fix for #155 

This is intended as a hot fix against tag 0.6 but since there's no release branch I can't point the PR at that directly.

Changes are simply to capture the `.count` computed property values into local variables before each `withUnsafeMutableBytes` call to avoid exclusive access errors, as described at https://forums.swift.org/t/upgrading-exclusive-access-warning-to-be-an-error-in-swift-4-2/12704