### PR TITLE
Expose features needed to implement the Scuttlebutt Protocol

### DIFF
--- a/Sodium.xcodeproj/project.pbxproj
+++ b/Sodium.xcodeproj/project.pbxproj
@@ -54,6 +54,9 @@
 		90C75EEC1AE3583E00F1E749 /* Sodium.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D80541A4ECCD7000B83F9 /* Sodium.swift */; };
 		90C75EED1AE3583E00F1E749 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D805C1A4F4F72000B83F9 /* Utils.swift */; };
 		A0918C781E92489100C1DC33 /* Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0918C771E92489100C1DC33 /* Auth.swift */; };
+		B2BF08A220CA31F300C3AC8A /* Advanced.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BF08A120CA31F200C3AC8A /* Advanced.swift */; };
+		B2BF08A320CA346000C3AC8A /* Advanced.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BF08A120CA31F200C3AC8A /* Advanced.swift */; };
+		B2BF08A420CA346600C3AC8A /* Aead.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87EEC3F2063C655006C830D /* Aead.swift */; };
 		CFD847281BA8120900B1260F /* PWHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097F20D91AF127480088C2FE /* PWHash.swift */; };
 		D2A274061F13AD9300958702 /* KeyDerivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A274051F13AD9300958702 /* KeyDerivation.swift */; };
 		D85101041E22EF5B003DB2E8 /* ReadmeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85101031E22EF5B003DB2E8 /* ReadmeTests.swift */; };
@@ -202,6 +205,7 @@
 		90C75E941AE3571900F1E749 /* Sodium.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Sodium.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		90C75EAD1AE357CB00F1E749 /* libsodium-osx.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libsodium-osx.a"; sourceTree = "<group>"; };
 		A0918C771E92489100C1DC33 /* Auth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Auth.swift; sourceTree = "<group>"; };
+		B2BF08A120CA31F200C3AC8A /* Advanced.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Advanced.swift; sourceTree = "<group>"; };
 		D208E6BD1ECC7A69006D2137 /* sodium_lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sodium_lib.h; sourceTree = "<group>"; };
 		D2A274051F13AD9300958702 /* KeyDerivation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyDerivation.swift; sourceTree = "<group>"; };
 		D85101031E22EF5B003DB2E8 /* ReadmeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadmeTests.swift; sourceTree = "<group>"; };
@@ -310,6 +314,7 @@
 				D2A274051F13AD9300958702 /* KeyDerivation.swift */,
 				09A5AC111F74466700D3200B /* SecretStream.swift */,
 				F87EEC3F2063C655006C830D /* Aead.swift */,
+				B2BF08A120CA31F200C3AC8A /* Advanced.swift */,
 			);
 			path = Sodium;
 			sourceTree = "<group>";
@@ -702,6 +707,7 @@
 				7D6373E21E7B5E0800F04E72 /* KeyExchange.swift in Sources */,
 				095D80551A4ECCD7000B83F9 /* Sodium.swift in Sources */,
 				097F20DA1AF127480088C2FE /* PWHash.swift in Sources */,
+				B2BF08A220CA31F300C3AC8A /* Advanced.swift in Sources */,
 				DD1E4D0F20922C9E00BE7A3F /* ExitCode.swift in Sources */,
 				038365151A5A51D20081136D /* SecretBox.swift in Sources */,
 				095D805D1A4F4F72000B83F9 /* Utils.swift in Sources */,
@@ -771,10 +777,12 @@
 				DD1E4D1020922C9E00BE7A3F /* ExitCode.swift in Sources */,
 				DD35BB6420932A83006BF351 /* Bytes.swift in Sources */,
 				6096E7321F194FA800E6599F /* KeyDerivation.swift in Sources */,
+				B2BF08A420CA346600C3AC8A /* Aead.swift in Sources */,
 				098DAF041F76E35C00DFB1C3 /* SecretStream.swift in Sources */,
 				90C75EEA1AE3583E00F1E749 /* ShortHash.swift in Sources */,
 				90C75EEB1AE3583E00F1E749 /* Sign.swift in Sources */,
 				DD35BB5B20925566006BF351 /* SecretKeyGenerator.swift in Sources */,
+				B2BF08A320CA346000C3AC8A /* Advanced.swift in Sources */,
 				90C75EEC1AE3583E00F1E749 /* Sodium.swift in Sources */,
 				90C75EED1AE3583E00F1E749 /* Utils.swift in Sources */,
 			);

--- a/Sodium/Advanced.swift
+++ b/Sodium/Advanced.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Clibsodium
+
+public class Advanced {
+}
+
+// Diffie-Hellman
+public extension Advanced {
+    
+    /**
+     Scalar multiplication of elliptic curve points.
+     
+     - Parameter n: typically a secret key.
+     - Parameter p: typically a public key
+     
+     - Returns: typically a shared secret
+     */
+    
+    public func scalarMult(n: Box.SecretKey, p: Box.PublicKey) -> Bytes? {
+        var q = Bytes(count: Int(crypto_scalarmult_SCALARBYTES))
+        guard .SUCCESS == crypto_scalarmult(&q, n, p).exitCode else { return nil }
+        return q
+    }
+    
+}
+
+// Ed25519 to Curve25519
+public extension Advanced {
+    
+    /**
+     Converts from Ed25519 key to Curve25519 key
+     
+     - Parameter sk: the secret key in Ed25519 format
+     
+     - Returns: the secret key in Curve25519 format
+     */
+    
+    public func toCurve25519(sk: Sign.SecretKey) -> Box.SecretKey? {
+        var r = Bytes(count: Int(crypto_sign_SECRETKEYBYTES))
+        guard .SUCCESS == crypto_sign_ed25519_sk_to_curve25519(&r, sk).exitCode else { return nil }
+        return r
+    }
+    
+    /**
+     Converts from Ed25519 key to Curve25519 key
+     
+     - Parameter pk: the public key in Ed25519 format
+     
+     - Returns: the public key in Curve25519 format
+     */
+    
+    public func toCurve25519(pk: Sign.PublicKey) -> Box.PublicKey? {
+        var r = Bytes(count: Int(crypto_sign_PUBLICKEYBYTES))
+        guard .SUCCESS == crypto_sign_ed25519_pk_to_curve25519(&r, pk).exitCode else { return nil }
+        return r
+    }
+    
+}
+
+// SHA-2
+public extension Advanced {
+    
+    /**
+     A single-part SHA-256 calculation
+ 
+     - Parameter input: raw data
+     
+     - Returns: a SHA256 digest
+     */
+    
+    public func SHA256(_ input: Bytes) -> Bytes? {
+        
+        var out = Bytes(count: Int(crypto_hash_sha256_BYTES))
+        guard .SUCCESS == crypto_hash_sha256(&out, input, UInt64(input.count)).exitCode else { return nil }
+        return out
+    }
+    
+    /**
+     A single-part SHA-512 calculation
+     
+     - Parameter input: raw data
+     
+     - Returns: a SHA512 digest
+     */
+    
+    public func SHA512(_ input: Bytes) -> Bytes? {
+        
+        var out = Bytes(count: Int(crypto_hash_sha512_BYTES))
+        guard .SUCCESS == crypto_hash_sha512(&out, input, UInt64(input.count)).exitCode else { return nil }
+        return out
+    }
+}

--- a/Sodium/SecretBox.swift
+++ b/Sodium/SecretBox.swift
@@ -30,18 +30,35 @@ public class SecretBox {
      - Returns: The authenticated ciphertext and encryption nonce.
      */
     public func seal(message: Bytes, secretKey: Key) -> (authenticatedCipherText: Bytes, nonce: Nonce)? {
+        
+        let nonce = self.nonce()
+        guard let authenticatedCipherText = seal(message: message, secretKey: secretKey, nonce: nonce) else {
+            return nil
+        }
+        return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
+    }
+    
+    /**
+     Encrypts a message with a shared secret key.
+     
+     - Parameter message: The message to encrypt.
+     - Parameter secretKey: The shared secret key.
+     - Parameter nonce: A nonce
+     
+     - Returns: The authenticated ciphertext and encryption nonce.
+     */
+    public func seal(message: Bytes, secretKey: Key, nonce: Nonce) -> Bytes? {
         guard secretKey.count == KeyBytes else { return nil }
         var authenticatedCipherText = Bytes(count: message.count + MacBytes)
-        let nonce = self.nonce()
 
         guard .SUCCESS == crypto_secretbox_easy (
             &authenticatedCipherText,
             message, UInt64(message.count),
             nonce,
             secretKey
-        ).exitCode else { return nil }
-
-        return (authenticatedCipherText: authenticatedCipherText, nonce: nonce)
+            ).exitCode else { return nil }
+        
+        return authenticatedCipherText
     }
 
     /**

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -16,6 +16,7 @@ public class Sodium {
     public let keyDerivation = KeyDerivation()
     public let secretStream = SecretStream()
     public let aead = Aead()
+    public let advanced = Advanced()
 
     private static let once: Void = {
         guard sodium_init() >= 0 else {

--- a/Tests/SodiumTests/SodiumTests.swift
+++ b/Tests/SodiumTests/SodiumTests.swift
@@ -438,7 +438,7 @@ class SodiumTests: XCTestCase {
         let pair2 = sodium.box.keyPair()
         let shared1 = sodium.advanced.scalarMult(n: pair1!.secretKey, p: pair2!.publicKey)
         let shared2 = sodium.advanced.scalarMult(n: pair2!.secretKey, p: pair1!.publicKey)
-        XCTAssertEqual(shared1, shared2)
+        XCTAssertEqual(shared1!, shared2!)
     }
     
     func testAdvancedEd25519ToCurve25519() {
@@ -450,20 +450,20 @@ class SodiumTests: XCTestCase {
         let sk2 = sodium.advanced.toCurve25519(sk: signPair2!.secretKey)
         let shared1 = sodium.advanced.scalarMult(n: sk1!, p: pk2!)
         let shared2 = sodium.advanced.scalarMult(n: sk2!, p: pk1!)
-        XCTAssertEqual(shared1, shared2)
+        XCTAssertEqual(shared1!, shared2!)
     }
     
     func testAdvancedSha2() {
         let hash1 = sodium.advanced.SHA256("abc".bytes)!
         let expected1 = [UInt8](Data(base64Encoded: "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=")!)
         XCTAssertEqual(hash1, expected1)
-        let hash2 = sodium.advanced.SHA256("".bytes)
+        let hash2 = sodium.advanced.SHA256("".bytes)!
         let expected2 = [UInt8](Data(base64Encoded: "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=")!)
         XCTAssertEqual(hash2, expected2)
-        let hash3 = sodium.advanced.SHA512("abc".bytes)
+        let hash3 = sodium.advanced.SHA512("abc".bytes)!
         let expected3 = [UInt8](Data(base64Encoded: "3a81oZNherrMQXNJriBBMRLm+k6JqX6iCp7u5ktV05ohkpkqJ0/BqDa6PCOj/uu9RU1EI2Q86A4qmslPpUyknw==")!)
         XCTAssertEqual(hash3, expected3)
-        let hash4 = sodium.advanced.SHA512("".bytes)
+        let hash4 = sodium.advanced.SHA512("".bytes)!
         let expected4 = [UInt8](Data(base64Encoded: "z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg==")!)
         XCTAssertEqual(hash4, expected4)
     }

--- a/Tests/SodiumTests/SodiumTests.swift
+++ b/Tests/SodiumTests/SodiumTests.swift
@@ -36,6 +36,10 @@ class SodiumTests: XCTestCase {
         ("testSignature", testSignature),
         ("testStream", testStream),
         ("testUtils", testUtils),
+        ("testAead", testAead),
+        ("testAdvancedDiffieHellman", testAdvancedDiffieHellman),
+        ("testAdvancedEd25519ToCurve25519", testAdvancedEd25519ToCurve25519),
+        ("testAdvancedSha2", testAdvancedSha2),
     ]
 
     let sodium = Sodium()
@@ -427,5 +431,40 @@ class SodiumTests: XCTestCase {
         let decryptedEmpty: Bytes = sodium.aead.xchacha20poly1305ietf.decrypt(nonceAndAuthenticatedCipherText: encryptedEmpty, secretKey: secretKey, additionalData: additionalData)!
         
         XCTAssertTrue(decryptedEmpty == emptyMessage)
+    }
+    
+    func testAdvancedDiffieHellman() {
+        let pair1 = sodium.box.keyPair()
+        let pair2 = sodium.box.keyPair()
+        let shared1 = sodium.advanced.scalarMult(n: pair1!.secretKey, p: pair2!.publicKey)
+        let shared2 = sodium.advanced.scalarMult(n: pair2!.secretKey, p: pair1!.publicKey)
+        XCTAssertEqual(shared1, shared2)
+    }
+    
+    func testAdvancedEd25519ToCurve25519() {
+        let signPair1 = sodium.sign.keyPair()
+        let signPair2 = sodium.sign.keyPair()
+        let pk1 = sodium.advanced.toCurve25519(pk: signPair1!.publicKey)
+        let sk1 = sodium.advanced.toCurve25519(sk: signPair1!.secretKey)
+        let pk2 = sodium.advanced.toCurve25519(pk: signPair2!.publicKey)
+        let sk2 = sodium.advanced.toCurve25519(sk: signPair2!.secretKey)
+        let shared1 = sodium.advanced.scalarMult(n: sk1!, p: pk2!)
+        let shared2 = sodium.advanced.scalarMult(n: sk2!, p: pk1!)
+        XCTAssertEqual(shared1, shared2)
+    }
+    
+    func testAdvancedSha2() {
+        let hash1 = sodium.advanced.SHA256("abc".bytes)!
+        let expected1 = [UInt8](Data(base64Encoded: "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=")!)
+        XCTAssertEqual(hash1, expected1)
+        let hash2 = sodium.advanced.SHA256("".bytes)
+        let expected2 = [UInt8](Data(base64Encoded: "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=")!)
+        XCTAssertEqual(hash2, expected2)
+        let hash3 = sodium.advanced.SHA512("abc".bytes)
+        let expected3 = [UInt8](Data(base64Encoded: "3a81oZNherrMQXNJriBBMRLm+k6JqX6iCp7u5ktV05ohkpkqJ0/BqDa6PCOj/uu9RU1EI2Q86A4qmslPpUyknw==")!)
+        XCTAssertEqual(hash3, expected3)
+        let hash4 = sodium.advanced.SHA512("".bytes)
+        let expected4 = [UInt8](Data(base64Encoded: "z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg==")!)
+        XCTAssertEqual(hash4, expected4)
     }
 }


### PR DESCRIPTION
In order to implement the Scuttlebutt Protocol, a few more functions need to be exposed from the C Sodium library. Specifically:
- `crypto_scalarmult` is needed for the EC Diffie-Hellman computation,
- `crypto_sign_ed25519_pk_to_curve25519`/ `crypto_sign_ed25519_sk_to_curve25519` are needed so we can use the same keypair for signing and encryption,
- `crypto_hash_sha256` is used instead of the generic BLAKE2b.

Sodium's documentation puts them all in the Advanced section, that's why I am implementing a single Advanced class. Long term, it may be better to split it into separate categories?

Additionally, the current implementation of the SecretBox does not allow user to specify the nonce parameter manually, rather defaults to a random value. However, the protocol requires a fixed nonce value (all zeroes), so I have extended the SecretBox class with an additional `seal` method overload.

Reference:
https://ssbc.github.io/scuttlebutt-protocol-guide/
