### PR TITLE
Remove redundant state stream protocol

### DIFF
--- a/Sodium.xcodeproj/project.pbxproj
+++ b/Sodium.xcodeproj/project.pbxproj
@@ -58,8 +58,6 @@
 		CFD847281BA8120900B1260F /* PWHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097F20D91AF127480088C2FE /* PWHash.swift */; };
 		D2A274061F13AD9300958702 /* KeyDerivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A274051F13AD9300958702 /* KeyDerivation.swift */; };
 		D85101041E22EF5B003DB2E8 /* ReadmeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85101031E22EF5B003DB2E8 /* ReadmeTests.swift */; };
-		DD1E4D06208E744100BE7A3F /* StateStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1E4D05208E744100BE7A3F /* StateStream.swift */; };
-		DD1E4D07208E744100BE7A3F /* StateStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1E4D05208E744100BE7A3F /* StateStream.swift */; };
 		DD1E4D0F20922C9E00BE7A3F /* ExitCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1E4D0E20922C9E00BE7A3F /* ExitCode.swift */; };
 		DD1E4D1020922C9E00BE7A3F /* ExitCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1E4D0E20922C9E00BE7A3F /* ExitCode.swift */; };
 		DD35BB5020924A35006BF351 /* NonceGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB4F20924A35006BF351 /* NonceGenerator.swift */; };
@@ -207,7 +205,6 @@
 		D2A274051F13AD9300958702 /* KeyDerivation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyDerivation.swift; sourceTree = "<group>"; };
 		D85101031E22EF5B003DB2E8 /* ReadmeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadmeTests.swift; sourceTree = "<group>"; };
 		D85101051E22F77E003DB2E8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		DD1E4D05208E744100BE7A3F /* StateStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateStream.swift; sourceTree = "<group>"; };
 		DD1E4D0E20922C9E00BE7A3F /* ExitCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExitCode.swift; sourceTree = "<group>"; };
 		DD35BB4F20924A35006BF351 /* NonceGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonceGenerator.swift; sourceTree = "<group>"; };
 		DD35BB5220924B6F006BF351 /* KeyPairGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPairGenerator.swift; sourceTree = "<group>"; };
@@ -296,7 +293,6 @@
 				DD35BB6220932A83006BF351 /* Bytes.swift */,
 				DD35BB58209252BF006BF351 /* Generators */,
 				DD1E4D0E20922C9E00BE7A3F /* ExitCode.swift */,
-				DD1E4D05208E744100BE7A3F /* StateStream.swift */,
 				038365141A5A51D20081136D /* SecretBox.swift */,
 				0942982F1EDDAA3B001236B1 /* Stream.swift */,
 				095D80561A4ED0B4000B83F9 /* GenericHash.swift */,
@@ -710,7 +706,6 @@
 				091C7CDC1A50839D002E5351 /* Sign.swift in Sources */,
 				DD35BB5320924B6F006BF351 /* KeyPairGenerator.swift in Sources */,
 				A0918C781E92489100C1DC33 /* Auth.swift in Sources */,
-				DD1E4D06208E744100BE7A3F /* StateStream.swift in Sources */,
 				094298301EDDAA3B001236B1 /* Stream.swift in Sources */,
 				D2A274061F13AD9300958702 /* KeyDerivation.swift in Sources */,
 				DD35BB6320932A83006BF351 /* Bytes.swift in Sources */,
@@ -769,7 +764,6 @@
 				DD35BB5720924D3A006BF351 /* KeyPairProtocol.swift in Sources */,
 				60C211E71EB73D3900882AD0 /* Auth.swift in Sources */,
 				094298311EDDAA3B001236B1 /* Stream.swift in Sources */,
-				DD1E4D07208E744100BE7A3F /* StateStream.swift in Sources */,
 				DD1E4D1020922C9E00BE7A3F /* ExitCode.swift in Sources */,
 				DD35BB6420932A83006BF351 /* Bytes.swift in Sources */,
 				6096E7321F194FA800E6599F /* KeyDerivation.swift in Sources */,

--- a/Sodium/GenericHash.swift
+++ b/Sodium/GenericHash.swift
@@ -13,7 +13,7 @@ public struct GenericHash {
 
 extension GenericHash {
     public class Stream {
-        private var state: State
+        private var state: crypto_generichash_state
         public var outputLength: Int = 0
 
         init?(key: Bytes?, outputLength: Int) {
@@ -144,11 +144,6 @@ extension GenericHash.Stream {
 
         return output
     }
-}
-
-extension GenericHash.Stream: StateStream {
-    typealias State = crypto_generichash_state
-    static let capacity = crypto_generichash_statebytes()
 }
 
 extension GenericHash: SecretKeyGenerator {

--- a/Sodium/SecretStream.swift
+++ b/Sodium/SecretStream.swift
@@ -26,7 +26,7 @@ extension SecretStream.XChaCha20Poly1305 {
 
 extension SecretStream.XChaCha20Poly1305 {
     public class PushStream {
-        private var state: State
+        private var state: crypto_secretstream_xchacha20poly1305_state
         private var _header: Header
 
         init?(secretKey: Key) {
@@ -46,7 +46,7 @@ extension SecretStream.XChaCha20Poly1305 {
 
 extension SecretStream.XChaCha20Poly1305 {
     public class PullStream {
-        private var state: State
+        private var state: crypto_secretstream_xchacha20poly1305_state
 
         init?(secretKey: Key, header: Header) {
             guard header.count == HeaderBytes, secretKey.count == KeyBytes else {
@@ -190,13 +190,3 @@ extension SecretStream.XChaCha20Poly1305: SecretKeyGenerator {
     public static var keygen: (UnsafeMutablePointer<UInt8>) -> Void = crypto_secretstream_xchacha20poly1305_keygen
 }
 
-
-extension SecretStream.XChaCha20Poly1305.PushStream: StateStream {
-    typealias State = crypto_secretstream_xchacha20poly1305_state
-    static let capacity = crypto_secretstream_xchacha20poly1305_statebytes()
-}
-
-extension SecretStream.XChaCha20Poly1305.PullStream: StateStream {
-    typealias State = crypto_secretstream_xchacha20poly1305_state
-    static let capacity = crypto_secretstream_xchacha20poly1305_statebytes()
-}

--- a/Sodium/StateStream.swift
+++ b/Sodium/StateStream.swift
@@ -1,5 +1,0 @@
-protocol StateStream {
-    associatedtype State
-
-    static var capacity: Int { get }
-}


### PR DESCRIPTION
The [`StateStream`](https://github.com/jedisct1/swift-sodium/blob/d918fdbfe95879b1a7c78a9607bc1a03a45fcf22/Sodium/StateStream.swift) protocol (added in #140) is probably now redundant due to the work on removing pointers in #148 (which removed the need for the shared memory freeing methods).

It is possible that it would be desirable to keep the protocol to highlight the structural similarity among the various streams—however the protocol is no longer required for the code sharing (this was the original motivation for adding it).