### PR TITLE
Add parameter to specify nonce

### DIFF
--- a/Sodium/Aead.swift
+++ b/Sodium/Aead.swift
@@ -33,7 +33,10 @@ extension Aead.XChaCha20Poly1305Ietf {
     }
 
     /**
-     Encrypts a message with a shared secret key.
+     Encrypts a message with a shared secret key and a specified nonce that
+     should NEVER be reused with this key. If your use case does not REQUIRE
+     choosing the nonce value, use encrypt(message:secretKey:additionalData:)
+     instead.
 
      - Parameter message: The message to encrypt.
      - Parameter secretKey: The shared secret key.

--- a/Tests/SodiumTests/SodiumTests.swift
+++ b/Tests/SodiumTests/SodiumTests.swift
@@ -420,7 +420,25 @@ class SodiumTests: XCTestCase {
         let decrypted4: Bytes = sodium.aead.xchacha20poly1305ietf.decrypt(nonceAndAuthenticatedCipherText: nonceAndAuthenticatedCipherTextWithAddData, secretKey: secretKey, additionalData: additionalData)!
         
         XCTAssertTrue(decrypted4 == message)
-        
+
+        let nonce1 = sodium.randomBytes.buf(length: sodium.aead.xchacha20poly1305ietf.NonceBytes)!
+        let authenticatedCipherText2: Bytes = sodium.aead.xchacha20poly1305ietf.encrypt(message: message, secretKey: secretKey, nonce: nonce1)!
+        let decrypted5: Bytes = sodium.aead.xchacha20poly1305ietf.decrypt(authenticatedCipherText: authenticatedCipherText2, secretKey: secretKey, nonce: nonce1)!
+
+        XCTAssertTrue(decrypted5 == message)
+
+        let nonce2 = sodium.randomBytes.buf(length: sodium.aead.xchacha20poly1305ietf.NonceBytes)!
+        let authenticatedCipherTextWithAddData: Bytes = sodium.aead.xchacha20poly1305ietf.encrypt(message: message, secretKey: secretKey, nonce: nonce2, additionalData: additionalData)!
+        let decrypted6: Bytes = sodium.aead.xchacha20poly1305ietf.decrypt(authenticatedCipherText: authenticatedCipherTextWithAddData, secretKey: secretKey, nonce: nonce2, additionalData: additionalData)!
+
+        XCTAssertTrue(decrypted6 == message)
+
+        // encrypt with incorrect nonce-length
+        let badNonce = sodium.randomBytes.buf(length: sodium.aead.xchacha20poly1305ietf.NonceBytes + 1)!
+        let authenticatedCipherTextFromBadNonce: Bytes? = sodium.aead.xchacha20poly1305ietf.encrypt(message: message, secretKey: secretKey, nonce: badNonce, additionalData: additionalData)
+
+        XCTAssertNil(authenticatedCipherTextFromBadNonce)
+
         // encrypt -> decrypt empty message
         let emptyMessage = "".bytes
         let encryptedEmpty: Bytes = sodium.aead.xchacha20poly1305ietf.encrypt(message: emptyMessage, secretKey: secretKey, additionalData: additionalData)!


### PR DESCRIPTION
It seems that the current Swift API doesn't permit this currently. I wonder if this could be included in a way such that is is slightly more hidden away from the main AEAD API?
This might be too much of a foot-gun to justify including, so if there are concerns I'm happy for the result of this PR to be that it is closed and not merged.