### PR TITLE
Ensure examples compile on Xcode 10.2

### DIFF
--- a/Examples/CommonCode/Helpers.swift
+++ b/Examples/CommonCode/Helpers.swift
@@ -8,7 +8,11 @@ extension String {
 
 extension Dictionary {
     func toData() -> Data? {
-        return try! NSKeyedArchiver.archivedData(withRootObject: self, requiringSecureCoding: false) as Data?
+        if #available(iOS 11.0, *) {
+            return try? NSKeyedArchiver.archivedData(withRootObject: self, requiringSecureCoding: false)
+        } else {
+            return NSKeyedArchiver.archivedData(withRootObject: self)
+        }
     }
 }
 
@@ -18,7 +22,10 @@ extension Data {
     }
 
     func toDictionary() -> [String: AnyObject]? {
-        #error("Please update this to use unarchivedObjectOfClass: fromData:")
-        return NSKeyedUnarchiver.unarchiveObject(with: self) as? [String: AnyObject]
+        if #available(iOS 9.0, *) {
+            return try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(self) as? [String: AnyObject]
+        } else {
+            return NSKeyedUnarchiver.unarchiveObject(with: self) as? [String: AnyObject]
+        }
     }
 }

--- a/Examples/CommonCode/Helpers.swift
+++ b/Examples/CommonCode/Helpers.swift
@@ -8,7 +8,7 @@ extension String {
 
 extension Dictionary {
     func toData() -> Data? {
-        if #available(iOS 11.0, *) {
+        if #available(iOS 11.0, macOS 10.13, *) {
             return try? NSKeyedArchiver.archivedData(withRootObject: self, requiringSecureCoding: false)
         } else {
             return NSKeyedArchiver.archivedData(withRootObject: self)

--- a/Sodium.xcodeproj/project.pbxproj
+++ b/Sodium.xcodeproj/project.pbxproj
@@ -1394,7 +1394,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1415,7 +1415,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Sodium.xcodeproj/project.pbxproj
+++ b/Sodium.xcodeproj/project.pbxproj
@@ -1389,7 +1389,7 @@
 				);
 				INFOPLIST_FILE = Examples/OSX/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.vucontacts.swiftodium.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1410,7 +1410,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = Examples/OSX/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.vucontacts.swiftodium.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;


### PR DESCRIPTION
Add `#availability` checks to ensure examples are Xcode 10.2 compatible.