### PR TITLE
Add HMAC-SHA-256/512/512-256 and support for multi-part message HMACs

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ if sodium.pwHash.strNeedsRehash(hash: hashedStr,
 
 ## Authentication tags
 
+### Single-part messages
+
 The `sodium.auth.tag()` function computes an authentication tag (HMAC) using a message and a key. Parties knowing the key can then verify the authenticity of the message using the same parameters and the `sodium.auth.verify()` function.
 
 Authentication tags are not signatures: the same key is used both for computing and verifying a tag. Therefore, verifiers can also compute tags for arbitrary messages.
@@ -278,6 +280,29 @@ let input = "test".bytes
 let key = sodium.auth.key()
 let tag = sodium.auth.tag(message: input, secretKey: key)!
 let tagIsValid = sodium.auth.verify(message: input, secretKey: key, tag: tag)
+```
+
+Note: This method uses SHA-512-256 for hashing. SHA-256, SHA-512 and also SHA-512-256 are available via the `sodium.hmac.authenticate()` function.
+
+### Multi-part messages
+
+Instead of providing the whole message at a time it is possible to split the message into several parts that can then be passed into the HMAC calculation over time. This can be useful especially when dealing with streaming data.
+
+```swift
+let sodium = Sodium()
+let key = sodium.hmac.key(alg: .sha256)!
+let multiPart = sodium.hmac.initMultiPartHMAC(key: key, alg: .sha256)!
+
+let inputPart1 = "This is a".bytes
+multiPart.update(message: inputPart1)
+
+let inputPart2 = "multi-part message".bytes
+multiPart.update(message: inputPart2)
+
+let hmac = multiPart.final()!
+let completeMessage = "This is a multi-part message".bytes
+
+let hmacIsValid = sodium.hmac.verify(hmac: hmac, message: completeMessage, key: key, alg: .sha256)
 ```
 
 ## Key derivation

--- a/Sodium.xcodeproj/project.pbxproj
+++ b/Sodium.xcodeproj/project.pbxproj
@@ -103,6 +103,9 @@
 		DD35BB5B20925566006BF351 /* SecretKeyGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB5920925566006BF351 /* SecretKeyGenerator.swift */; };
 		DD35BB6320932A83006BF351 /* Bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB6220932A83006BF351 /* Bytes.swift */; };
 		DD35BB6420932A83006BF351 /* Bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB6220932A83006BF351 /* Bytes.swift */; };
+		E5ED961E227C44CC007CF13F /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5ED961D227C44CC007CF13F /* HMAC.swift */; };
+		E5ED961F227C44D4007CF13F /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5ED961D227C44CC007CF13F /* HMAC.swift */; };
+		E5ED9620227C44D5007CF13F /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5ED961D227C44CC007CF13F /* HMAC.swift */; };
 		F87EEC402063C655006C830D /* Aead.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87EEC3F2063C655006C830D /* Aead.swift */; };
 /* End PBXBuildFile section */
 
@@ -308,6 +311,7 @@
 		DD35BB5520924D3A006BF351 /* KeyPairProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPairProtocol.swift; sourceTree = "<group>"; };
 		DD35BB5920925566006BF351 /* SecretKeyGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretKeyGenerator.swift; sourceTree = "<group>"; };
 		DD35BB6220932A83006BF351 /* Bytes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bytes.swift; sourceTree = "<group>"; };
+		E5ED961D227C44CC007CF13F /* HMAC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMAC.swift; sourceTree = "<group>"; };
 		F87EEC3F2063C655006C830D /* Aead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Aead.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -424,6 +428,7 @@
 				D2A274051F13AD9300958702 /* KeyDerivation.swift */,
 				09A5AC111F74466700D3200B /* SecretStream.swift */,
 				F87EEC3F2063C655006C830D /* Aead.swift */,
+				E5ED961D227C44CC007CF13F /* HMAC.swift */,
 			);
 			path = Sodium;
 			sourceTree = "<group>";
@@ -971,6 +976,7 @@
 				095D80571A4ED0B4000B83F9 /* GenericHash.swift in Sources */,
 				DD35BB5620924D3A006BF351 /* KeyPairProtocol.swift in Sources */,
 				F87EEC402063C655006C830D /* Aead.swift in Sources */,
+				E5ED961E227C44CC007CF13F /* HMAC.swift in Sources */,
 				094F21EA1A5017CA001C3141 /* Box.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1027,6 +1033,7 @@
 				90C75EEB1AE3583E00F1E749 /* Sign.swift in Sources */,
 				DD35BB5B20925566006BF351 /* SecretKeyGenerator.swift in Sources */,
 				90C75EEC1AE3583E00F1E749 /* Sodium.swift in Sources */,
+				E5ED961F227C44D4007CF13F /* HMAC.swift in Sources */,
 				90C75EED1AE3583E00F1E749 /* Utils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1065,6 +1072,7 @@
 				D891FEAF2164323A0092AA84 /* Auth.swift in Sources */,
 				D891FEB02164323A0092AA84 /* KeyDerivation.swift in Sources */,
 				D891FEB12164323A0092AA84 /* SecretStream.swift in Sources */,
+				E5ED9620227C44D5007CF13F /* HMAC.swift in Sources */,
 				D891FEB22164323A0092AA84 /* Aead.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sodium/HMAC.swift
+++ b/Sodium/HMAC.swift
@@ -1,0 +1,230 @@
+import Foundation
+import Clibsodium
+
+public struct HMAC {
+    public static let HMACSHA256Bytes = Int(crypto_auth_hmacsha256_bytes())
+    public static let HMACSHA512Bytes = Int(crypto_auth_hmacsha512_bytes())
+    public static let HMACSHA512256Bytes = Int(crypto_auth_hmacsha512256_bytes())
+
+    public let HMACSHA256KeyBytes = Int(crypto_auth_hmacsha256_keybytes())
+    public let HMACSHA512KeyBytes = Int(crypto_auth_hmacsha512_keybytes())
+    public let HMACSHA512256KeyBytes = Int(crypto_auth_hmacsha512256_keybytes())
+}
+
+extension HMAC {
+    public enum Alg {
+        case sha256
+        case sha512
+        case sha512256
+    }
+
+    /**
+     This helper function creates a random key.
+
+     - Parameter alg: the hashing algorithm (SHA-256, SHA-512 or SHA-512-256)
+
+     - Returns: a random key or `nil` if the key cannot be created.
+     */
+    public func key(alg: Alg) -> Bytes? {
+        var output: Bytes
+
+        switch alg {
+        case .sha256:
+            output = Bytes(count: HMACSHA256KeyBytes)
+            crypto_auth_hmacsha256_keygen(&output)
+        case .sha512:
+            output = Bytes(count: HMACSHA512KeyBytes)
+            crypto_auth_hmacsha512_keygen(&output)
+        case .sha512256:
+            output = Bytes(count: HMACSHA512256KeyBytes)
+            crypto_auth_hmacsha512256_keygen(&output)
+        }
+
+        return output
+    }
+
+    /**
+     This function calculates a message authentication code (HMAC) for a single given message and a given key using the provided hash algorithm.
+
+     - Parameter message: the message that should be authenticated
+     - Parameter key: the key that is being used calculating the HMAC
+     - Parameter alg: the hashing algorithm (SHA-256, SHA-512 or SHA-512-256)
+
+     - Returns: an authenticator (HMAC) for the given message and key using the provided hash algorithm. If the HMAC cannot be calculated this method returns `nil`.
+     */
+    public func authenticate(message: Bytes, key: Bytes, alg: Alg) -> Bytes? {
+        guard key.count == keyLength(alg: alg) else { return nil }
+
+        var output: Bytes
+
+        switch alg {
+        case .sha256:
+            output = Bytes(count: HMAC.HMACSHA256Bytes)
+            guard .SUCCESS == crypto_auth_hmacsha256(&output, message, UInt64(message.count), key).exitCode else { return nil }
+        case .sha512:
+            output = Bytes(count: HMAC.HMACSHA512Bytes)
+            guard .SUCCESS == crypto_auth_hmacsha512(&output, message, UInt64(message.count), key).exitCode else { return nil }
+        case .sha512256:
+            output = Bytes(count: HMAC.HMACSHA512256Bytes)
+            guard .SUCCESS == crypto_auth_hmacsha512256(&output, message, UInt64(message.count), key).exitCode else { return nil }
+        }
+
+        return output
+    }
+
+    /**
+     This function verifies that a given authenticator (HMAC) is correct for the given message and a key.
+
+     - Parameter hmac: the authenticator (HMAC)
+     - Parameter message: the message that is authenticated
+     - Parameter key: the key that is being used verify the HMAC
+     - Parameter alg: the hashing algorithm (SHA-256, SHA-512 or SHA-512-256) used for calculating the HMAC
+
+     - Returns: true if the verification succeeds, false otherwise.
+     */
+    public func verify(hmac: Bytes, message: Bytes, key: Bytes, alg: Alg) -> Bool {
+        guard key.count == keyLength(alg: alg) else { return false }
+
+        switch alg {
+        case .sha256:
+            return .SUCCESS == crypto_auth_hmacsha256_verify(hmac, message, UInt64(message.count), key).exitCode
+        case .sha512:
+            return .SUCCESS == crypto_auth_hmacsha512_verify(hmac, message, UInt64(message.count), key).exitCode
+        case .sha512256:
+            return .SUCCESS == crypto_auth_hmacsha512256_verify(hmac, message, UInt64(message.count), key).exitCode
+        }
+    }
+
+    private func keyLength(alg: Alg) -> Int {
+        switch alg {
+        case .sha256:
+            return HMACSHA256KeyBytes
+        case .sha512:
+            return HMACSHA512KeyBytes
+        case .sha512256:
+            return HMACSHA512256KeyBytes
+        }
+    }
+}
+
+public protocol MultiPartHMAC {
+    func update(message: Bytes) -> Bool
+    func final() -> Bytes?
+}
+
+extension HMAC {
+    public class MultiPartHMACSHA256: MultiPartHMAC {
+        private var state: crypto_auth_hmacsha256_state
+
+        init?(key: Bytes) {
+            state = crypto_auth_hmacsha256_state()
+            guard .SUCCESS == crypto_auth_hmacsha256_init(&state, key, key.count).exitCode else { return nil}
+        }
+
+        /**
+         This function updates the HMAC by including another part of the message to be authenticated.
+
+         - Parameter message: the message part
+
+         - Returns: true if the given message part was included into the HMAC successfully, false otherwise.
+         */
+        public func update(message: Bytes) -> Bool {
+            guard .SUCCESS == crypto_auth_hmacsha256_update(&state, message, UInt64(message.count)).exitCode else { return false }
+            return true
+        }
+
+        /**
+         This function returns the HMAC for the message that consists of all parts passed into the `update` method. After calling this method you should not call `update` again.
+
+         - Returns: an authenticator (HMAC) for the given multi-part message or `nil` if the HMAC cannot be calculated.
+         */
+        public func final() -> Bytes? {
+            var output = Bytes(count: HMAC.HMACSHA256Bytes)
+            guard .SUCCESS == crypto_auth_hmacsha256_final(&state, &output).exitCode else { return nil }
+            return output
+        }
+    }
+
+    public class MultiPartHMACSHA512: MultiPartHMAC {
+        private var state: crypto_auth_hmacsha512_state
+
+        init?(key: Bytes) {
+            state = crypto_auth_hmacsha512_state()
+            guard .SUCCESS == crypto_auth_hmacsha512_init(&state, key, key.count).exitCode else { return nil}
+        }
+
+        /**
+         This function updates the HMAC by including another part of the message to be authenticated.
+
+         - Parameter message: the message part
+
+         - Returns: true if the given message part was included into the HMAC successfully, false otherwise.
+         */
+        public func update(message: Bytes) -> Bool {
+            guard .SUCCESS == crypto_auth_hmacsha512_update(&state, message, UInt64(message.count)).exitCode else { return false }
+            return true
+        }
+
+        /**
+         This function returns the HMAC for the message that consists of all parts passed into the `update` method. After calling this method you should not call `update` again.
+
+         - Returns: an authenticator (HMAC) for the given multi-part message or `nil` if the HMAC cannot be calculated.
+         */
+        public func final() -> Bytes? {
+            var output = Bytes(count: HMAC.HMACSHA512Bytes)
+            guard .SUCCESS == crypto_auth_hmacsha512_final(&state, &output).exitCode else { return nil }
+            return output
+        }
+    }
+
+    public class MultiPartHMACSHA512256: MultiPartHMAC {
+        private var state: crypto_auth_hmacsha512256_state
+
+        init?(key: Bytes) {
+            state = crypto_auth_hmacsha512256_state()
+            guard .SUCCESS == crypto_auth_hmacsha512256_init(&state, key, key.count).exitCode else { return nil}
+        }
+
+        /**
+         This function updates the HMAC by including another part of the message to be authenticated.
+
+         - Parameter message: the message part
+
+         - Returns: true if the given message part was included into the HMAC successfully, false otherwise.
+         */
+        public func update(message: Bytes) -> Bool {
+            guard .SUCCESS == crypto_auth_hmacsha512256_update(&state, message, UInt64(message.count)).exitCode else { return false }
+            return true
+        }
+
+        /**
+         This function returns the HMAC for the message that consists of all parts passed into the `update` method. After calling this method you should not call `update` again.
+
+         - Returns: an authenticator (HMAC) for the given multi-part message or `nil` if the HMAC cannot be calculated.
+         */
+        public func final() -> Bytes? {
+            var output = Bytes(count: HMAC.HMACSHA512256Bytes)
+            guard .SUCCESS == crypto_auth_hmacsha512256_final(&state, &output).exitCode else { return nil }
+            return output
+        }
+    }
+
+    /**
+     This function can be used to create a HMAC for a multi-part (streamed) message. After initializing the MultiPartHMAC object by providing the hash algorithm and the key to be used the `update` method can be called anytime a new part of the message should be included into the authenticator. Finally the `final` method returns the HMAC. Afterwards you should not call `update` on that object again.
+
+     - Parameter key: the key that is being used calculating the HMAC
+     - Parameter alg: the hashing algorithm (SHA-256, SHA-512 or SHA-512-256)
+
+     - Returns: an MultiPartHMAC object that can be used to include new parts of the message and return the final HMAC. If the MultiPartHMAC object cannot be initialized this method returns `nil`.
+     */
+    public func initMultiPartHMAC(key: Bytes, alg: Alg) -> MultiPartHMAC? {
+        switch alg {
+        case .sha256:
+            return MultiPartHMACSHA256(key: key)
+        case .sha512:
+            return MultiPartHMACSHA512(key: key)
+        case .sha512256:
+            return MultiPartHMACSHA512256(key: key)
+        }
+    }
+}

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -8,6 +8,7 @@ public struct Sodium {
     public let pwHash = PWHash()
     public let randomBytes = RandomBytes()
     public let shortHash = ShortHash()
+    public let hmac = HMAC()
     public let sign = Sign()
     public let utils = Utils()
     public let keyExchange = KeyExchange()

--- a/Tests/SodiumTests/SodiumTests.swift
+++ b/Tests/SodiumTests/SodiumTests.swift
@@ -33,6 +33,7 @@ class SodiumTests: XCTestCase {
         ("testSecretBox", testSecretBox),
         ("testSecretStream", testSecretStream),
         ("testShortHash", testShortHash),
+        ("testHMAC", testHMAC),
         ("testSignature", testSignature),
         ("testStream", testStream),
         ("testUtils", testUtils),
@@ -185,6 +186,33 @@ class SodiumTests: XCTestCase {
         let key = sodium.utils.hex2bin("00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff", ignore: " ")!
         let h = sodium.utils.bin2hex(sodium.shortHash.hash(message: message, key: key)!)!
         XCTAssertEqual(h, "bb9be85c918015ea")
+    }
+
+    func testHMAC() {
+        let message = "My Test Message".bytes
+        let key = sodium.utils.hex2bin("00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff 00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff", ignore: " ")!
+
+        let hmacsha256 = sodium.hmac.authenticate(message: message, key: key, alg: .sha256)!
+        XCTAssertTrue(sodium.hmac.verify(hmac: hmacsha256, message: message, key: key, alg: .sha256))
+        let multiPartSHA256 = sodium.hmac.initMultiPartHMAC(key: key, alg: .sha256)!
+        XCTAssertTrue(multiPartSHA256.update(message: message))
+        let multiPartHMACSHA256 = multiPartSHA256.final()!
+        XCTAssertTrue(sodium.hmac.verify(hmac: multiPartHMACSHA256, message: message, key: key, alg: .sha256))
+
+        let hmacsha512 = sodium.hmac.authenticate(message: message, key: key, alg: .sha512)!
+        XCTAssertTrue(sodium.hmac.verify(hmac: hmacsha512, message: message, key: key, alg: .sha512))
+        let multiPartSHA512 = sodium.hmac.initMultiPartHMAC(key: key, alg: .sha512)!
+        XCTAssertTrue(multiPartSHA512.update(message: message))
+        let multiPartHMACSHA512 = multiPartSHA512.final()!
+        XCTAssertTrue(sodium.hmac.verify(hmac: multiPartHMACSHA512, message: message, key: key, alg: .sha512))
+
+        let hmacsha512256 = sodium.hmac.authenticate(message: message, key: key, alg: .sha512256)!
+        XCTAssertTrue(sodium.hmac.verify(hmac: hmacsha512256, message: message, key: key, alg: .sha512256))
+        let multiPartSHA512256 = sodium.hmac.initMultiPartHMAC(key: key, alg: .sha512256)!
+        XCTAssertTrue(multiPartSHA512256.update(message: message))
+        let multiPartHMACSHA512256 = multiPartSHA512256.final()!
+        XCTAssertTrue(sodium.hmac.verify(hmac: multiPartHMACSHA512256, message: message, key: key, alg: .sha512256))
+
     }
 
     func testSignature() {


### PR DESCRIPTION
This implements the libsodium HMAC API which adds support for HMAC-SHA-512 and HMAC-SHA-256 (and also HMAC-SHA-512-256, but that has already been availably via `sodium.auth.tag()`).

```swift
let sodium = Sodium()
let message = "My Test Message".bytes
let key = sodium.hmac.key(alg: .sha256)!
let hmac = sodium.hmac.authenticate(message: message, key: key, alg: .sha256)!
let hmacIsValid = sodium.hmac.verify(hmac: hmac, message: message, key: key, alg: .sha256)
```

Furthermore it enables the HMAC calculation of multi-part messages (e.g. for streaming data).

```swift
let sodium = Sodium()
let key = sodium.hmac.key(alg: .sha256)!
let multiPart = sodium.hmac.initMultiPartHMAC(key: key, alg: .sha256)!

let inputPart1 = "This is a".bytes
multiPart.update(message: inputPart1)

let inputPart2 = "multi-part message".bytes
multiPart.update(message: inputPart2)

let hmac = multiPart.final()!

let completeMessage = "This is a multi-part message".bytes
let hmacIsValid = sodium.hmac.verify(hmac: hmac, message: completeMessage, key: key, alg: .sha256)
```