### PR TITLE
Correct constructor call

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ With public-key cryptography, each peer has two keys: a secret key, that has to 
 ### Authenticated Encryption
 
 ```swift
-let sodium = Sodium(())!
+let sodium = Sodium(())
 let aliceKeyPair = sodium.box.keyPair()!
 let bobKeyPair = sodium.box.keyPair()!
 let message = "My Test Message".bytes


### PR DESCRIPTION
`(())!` Passing void with unwrapping seems to be outdated