### PR TITLE
Add hmacsha256 auth functions

### DIFF
--- a/Sodium/Auth.swift
+++ b/Sodium/Auth.swift
@@ -47,6 +47,47 @@ extension Auth {
             secretKey
         ).exitCode
     }
+
+    /**
+     Computes an authentication tag for a message using a key
+
+     - Parameter message: The message to authenticate.
+     - Parameter secretKey: The key required to create and verify messages.
+
+     - Returns: The computed authentication tag.
+     */
+    public func hmacsha256(message: Bytes, secretKey: SecretKey) -> Bytes? {
+        guard secretKey.count == KeyBytes else { return nil }
+
+        var tag = Array<UInt8>(count: Bytes)
+        guard .SUCCESS == crypto_auth_hmacsha256 (
+            &tag,
+            message, UInt64(message.count),
+            secretKey
+        ).exitCode else { return nil }
+
+        return tag
+    }
+
+    /**
+     Verifies that an authentication tag is valid for a message and a key
+
+     - Parameter message: The message to verify.
+     - Parameter secretKey: The key required to create and verify messages.
+     - Parameter tag: The authentication tag.
+
+     - Returns: `true` if the verification is successful.
+     */
+    public func hmacsha256_verify(message: Bytes, secretKey: SecretKey, tag: Bytes) -> Bool {
+        guard secretKey.count == KeyBytes else {
+            return false
+        }
+        return .SUCCESS == crypto_auth_hmacsha256_verify (
+            tag,
+            message, UInt64(message.count),
+            secretKey
+        ).exitCode
+    }
 }
 
 extension Auth: SecretKeyGenerator {


### PR DESCRIPTION
I needed to use `crypto_auth_hmacsha256` in my Swift app and couldn't find a way to do it. This PR doesn't include the tagging methods for  HMAC-SHA-512 or HMAC-SHA512-256 (truncated HMAC-SHA-512), but consumers of this library may want to use those in the future as well. Let me know if I missed a way to use `crypto_auth_hmacsha256` with the existing Swift bindings, or if the purpose of this project it to provide a simplified subset of the functionality of LibSodium.