### PR TITLE
Add Clibsodium SPM library to fix Release builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ let package = Package(
     name: "Sodium",
     products: [
         .library(
+            name: "Clibsodium",
+            targets: ["Clibsodium"]),
+        .library(
             name: "Sodium",
             targets: ["Sodium"]),
     ],


### PR DESCRIPTION
This resolves building for Release when Sodium is a dependency via SPM. This may be an Xcode 12 beta bug, or I may be using it incorrectly, or it's actually working as intended (not that the documentation at all talks about this) but what I'm seeing is:

- Using the "Sodium" target directly will work for debug
- Release builds (iOS or Catalyst) complain `No such module 'Clibsodium'`
- Explicitly adding `Clibsodium` as a library to the target fixes compilation

Other things I tried:

- Adding `Clibsodium` to the `targets` array of the library
- Messing with `dependencies` of the Sodium target (it seems correct)
- Swapping between `static` and `dynamic` for the library