### PR TITLE
Fix the podspec to get it working with the XCFramework

### DIFF
--- a/Sodium.podspec
+++ b/Sodium.podspec
@@ -20,7 +20,7 @@ s.source_files = 'Sodium/**/*.{swift,h}'
 s.private_header_files = 'Sodium/libsodium/*.h'
 
 s.pod_target_xcconfig = {
-    'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_XCFRAMEWORKS_BUILD_DIR}/Clibsodium"'
+      'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_XCFRAMEWORKS_BUILD_DIR}/Clibsodium"'
 }
 
 s.requires_arc = true

--- a/Sodium.podspec
+++ b/Sodium.podspec
@@ -20,14 +20,7 @@ s.source_files = 'Sodium/**/*.{swift,h}'
 s.private_header_files = 'Sodium/libsodium/*.h'
 
 s.pod_target_xcconfig = {
-    'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_XCFRAMEWORKS_BUILD_DIR}/Clibsodium"',
-    # Remove following once Clibsodium.xcframework also targets arm64 for iOS and watchOS simulators
-    'EXCLUDED_ARCHS[sdk=*simulator*]' => 'arm64',
-}
-
-# Remove following once Clibsodium.xcframework also targets arm64 for iOS and watchOS simulators
-s.user_target_xcconfig = {
-    'EXCLUDED_ARCHS[sdk=*simulator*]' => 'arm64',
+    'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_XCFRAMEWORKS_BUILD_DIR}/Clibsodium"'
 }
 
 s.requires_arc = true

--- a/Sodium.podspec
+++ b/Sodium.podspec
@@ -1,4 +1,4 @@
-# Broken; use Swift Packages instead
+# Requires CocoaPods 1.10.0
 
 Pod::Spec.new do |s|
 s.name = 'Sodium'
@@ -10,7 +10,7 @@ s.homepage = 'https://github.com/jedisct1/swift-sodium'
 s.social_media_url = 'https://twitter.com/jedisct1'
 s.authors = { 'Frank Denis' => '' }
 s.source = { :git => 'https://github.com/jedisct1/swift-sodium.git',
-             :tag => '0.8.0' }
+             :tag => '0.9.0' }
 
 s.ios.deployment_target = '9.0'
 s.osx.deployment_target = '10.11'
@@ -20,7 +20,14 @@ s.source_files = 'Sodium/**/*.{swift,h}'
 s.private_header_files = 'Sodium/libsodium/*.h'
 
 s.pod_target_xcconfig = {
-	'SWIFT_INCLUDE_PATHS' => '$(PODS_TARGET_SRCROOT)/Sodium/libsodium',
+    'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_XCFRAMEWORKS_BUILD_DIR}/Clibsodium"',
+    # Remove following once Clibsodium.xcframework also targets arm64 for iOS and watchOS simulators
+    'EXCLUDED_ARCHS[sdk=*simulator*]' => 'arm64',
+}
+
+# Remove following once Clibsodium.xcframework also targets arm64 for iOS and watchOS simulators
+s.user_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=*simulator*]' => 'arm64',
 }
 
 s.requires_arc = true


### PR DESCRIPTION
This restores CocoaPods compatibility using the xcframework-based copy of Clibsodium but there are a few things to note:

- CocoaPods prior to 1.10.0 (current version is 1.10.0.rc.1) did not support XCFrameworks which wrap .a static libraries
- CocoaPods currently also has a bug where it in some circumstances, it uses the XCFramework's name for the `-l` linking flag (i.e. `-lClibsodium` instead of the correct library name (`-lsodium`). I've made a PR to fix that at https://github.com/CocoaPods/CocoaPods/pull/10072 and expect it to be merged shortly, before a final version of 1.10.0 is released.
- Meanwhile, in Xcode 12, `arm64` is a valid architecture for iOS and watchOS _simulator_ builds (because arm-based Macs), and is included in the default simulator architectures lists. Clibsodium.xcframework doesn't currently include arm64 in its simulator slices, which causes `pod lib lint` to fail, because by default that command targets simulators but with the Release configuration, which means it attempts to build _all_ architectures, and CocoaPods fails when the arm64 simulator slices cannot be found.

I've included a workaround for that last issue, by adding `'EXCLUDED_ARCHS[sdk=*simulator*]' => 'arm64'` to ensure Xcode doesn't attempt to build arm64+simulator. It can also be worked around by running `pod lib lint --configuration=Debug` instead, or (the better long-term solution) by adding arm64 to the simulator slices.