### PR TITLE
Explicitly exclude arm64 architecture in .podspec

### DIFF
--- a/Sodium.podspec
+++ b/Sodium.podspec
@@ -19,12 +19,25 @@ s.watchos.deployment_target = '5.0'
 s.source_files = 'Sodium/**/*.{swift,h}'
 s.private_header_files = 'Sodium/libsodium/*.h'
 
+# Xcode 12 changed the way apps are built because of the upcoming support for
+# Apple Silicon. We need explicitly exclude the arm64 architecture.
+# More info at
+# https://stackoverflow.com/questions/63607158/xcode-12-building-for-ios-simulator-but-linking-in-object-file-built-for-ios
 s.pod_target_xcconfig = {
-       'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_XCFRAMEWORKS_BUILD_DIR}/Clibsodium"'
+  'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_XCFRAMEWORKS_BUILD_DIR}/Clibsodium"',
+  'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64',
+  'EXCLUDED_ARCHS[sdk=watchsimulator*]' => 'arm64',
 }
 
+# Notice that a CocoaPods contributor discourages the use of
+# `user_target_xcconfig`, but in this case also agrees that there might not be
+# a better approach.
+# See
+# https://github.com/CocoaPods/CocoaPods/issues/10065#issuecomment-701055569
 s.user_target_xcconfig = {
-       'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_XCFRAMEWORKS_BUILD_DIR}/Clibsodium"'
+  'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_XCFRAMEWORKS_BUILD_DIR}/Clibsodium"',
+  'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64',
+  'EXCLUDED_ARCHS[sdk=watchsimulator*]' => 'arm64',
 }
 
 s.requires_arc = true


### PR DESCRIPTION
Relates to #213.

Xcode 12 changed the way apps are built because of the support for Apple Silicon (ARM chip). We need to explicitly exclude the arm64 architecture.

More info in [this StackOverflow question](https://stackoverflow.com/questions/63607158/xcode-12-building-for-ios-simulator-but-linking-in-object-file-built-for-ios).

Unfortunately **this doesn't yet fix the validation of the spec**. Nevertheless, even though I could be wrong, I think it's a step forward in the right direction.