### PR TITLE
Ensure Package.swift and Sodium.podspec both specify Swift 5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This PR:
- Sets `swift-tools-version` in `Package.swift` to 5.0 (to match `swift_version` setting in `Sodium.podspec`).

**N.B:**
- Reducing the `swift-tools-version` setting from 5.3 to 5.0 (to match the podspec file) also allows the library to be integrated using the 'Swift Packages' integration present in Xcode 11.x and above. (Whereas leaving it set at 5.3 meant that Xcode 12.x and above was required).