### PR TITLE
Add tvOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/
 xcuserdata
 .build
 Package.resolved
+.DS_Store

--- a/Examples/tvOS/AppDelegate.swift
+++ b/Examples/tvOS/AppDelegate.swift
@@ -1,0 +1,33 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+
+}
+

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ]
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ]
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
@@ -1,0 +1,32 @@
+{
+  "assets" : [
+    {
+      "filename" : "App Icon - App Store.imagestack",
+      "idiom" : "tv",
+      "role" : "primary-app-icon",
+      "size" : "1280x768"
+    },
+    {
+      "filename" : "App Icon.imagestack",
+      "idiom" : "tv",
+      "role" : "primary-app-icon",
+      "size" : "400x240"
+    },
+    {
+      "filename" : "Top Shelf Image Wide.imageset",
+      "idiom" : "tv",
+      "role" : "top-shelf-image-wide",
+      "size" : "2320x720"
+    },
+    {
+      "filename" : "Top Shelf Image.imageset",
+      "idiom" : "tv",
+      "role" : "top-shelf-image",
+      "size" : "1920x720"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image Wide.imageset/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image Wide.imageset/Contents.json
@@ -1,0 +1,24 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "tv-marketing",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv-marketing",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
@@ -1,0 +1,24 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "tv-marketing",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv-marketing",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Assets.xcassets/Contents.json
+++ b/Examples/tvOS/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/tvOS/Base.lproj/LaunchScreen.storyboard
+++ b/Examples/tvOS/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="13122.16" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="wu6-TO-1qx"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/tvOS/Base.lproj/tvOSMain.storyboard
+++ b/Examples/tvOS/Base.lproj/tvOSMain.storyboard
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="13122.16" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="wu6-TO-1qx"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/tvOS/Info.plist
+++ b/Examples/tvOS/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>tvOSMain</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Automatic</string>
+</dict>
+</plist>

--- a/Examples/tvOS/ViewController.swift
+++ b/Examples/tvOS/ViewController.swift
@@ -1,0 +1,38 @@
+import UIKit
+import Sodium
+
+class ViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let sodium = Sodium()
+        let aliceKeyPair = sodium.box.keyPair()!
+        let bobKeyPair = sodium.box.keyPair()!
+        let message = "My Test Message".bytes
+
+        print("Original Message:\(message.utf8String!)")
+
+        let encryptedMessageFromAliceToBob: Bytes =
+            sodium.box.seal(
+                message: message,
+                recipientPublicKey: bobKeyPair.publicKey,
+                senderSecretKey: aliceKeyPair.secretKey)!
+
+        print("Encrypted Message:\(encryptedMessageFromAliceToBob)")
+
+        let messageVerifiedAndDecryptedByBob =
+            sodium.box.open(
+                nonceAndAuthenticatedCipherText: encryptedMessageFromAliceToBob,
+                senderPublicKey: bobKeyPair.publicKey,
+                recipientSecretKey: aliceKeyPair.secretKey)
+
+        print("Decrypted Message:\(messageVerifiedAndDecryptedByBob!.utf8String!)")
+
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+    }
+}
+
+

--- a/Sodium.xcodeproj/project.pbxproj
+++ b/Sodium.xcodeproj/project.pbxproj
@@ -28,6 +28,38 @@
 		09A943D31A4EB5F500C8A04F /* Sodium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09A943C71A4EB5F500C8A04F /* Sodium.framework */; };
 		09A943DA1A4EB5F500C8A04F /* SodiumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A943D91A4EB5F500C8A04F /* SodiumTests.swift */; };
 		28FA5A1520C9E71F00D7BE2B /* Aead.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87EEC3F2063C655006C830D /* Aead.swift */; };
+		53008F84253608B0006FE4EF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53008F7F253608B0006FE4EF /* ViewController.swift */; };
+		53008F86253608B0006FE4EF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 53008F81253608B0006FE4EF /* Assets.xcassets */; };
+		53008F87253608B0006FE4EF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53008F82253608B0006FE4EF /* AppDelegate.swift */; };
+		53008F8D253608D6006FE4EF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 53008F89253608D6006FE4EF /* LaunchScreen.storyboard */; };
+		53008F8E253608D6006FE4EF /* tvOSMain.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 53008F8B253608D6006FE4EF /* tvOSMain.storyboard */; };
+		53008F9825360973006FE4EF /* Sodium.h in Headers */ = {isa = PBXBuildFile; fileRef = 53008F9625360973006FE4EF /* Sodium.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		53008F9C2536098E006FE4EF /* Clibsodium.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 093EFE3E24DB1E1400D7ED92 /* Clibsodium.xcframework */; };
+		53008F9D2536098E006FE4EF /* Clibsodium.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 093EFE3E24DB1E1400D7ED92 /* Clibsodium.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		53008F9F253609D1006FE4EF /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094F21E91A5017CA001C3141 /* Box.swift */; };
+		53008FA0253609D1006FE4EF /* Bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB6220932A83006BF351 /* Bytes.swift */; };
+		53008FA1253609D1006FE4EF /* NonceGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB4F20924A35006BF351 /* NonceGenerator.swift */; };
+		53008FA2253609D1006FE4EF /* KeyPairGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB5220924B6F006BF351 /* KeyPairGenerator.swift */; };
+		53008FA3253609D1006FE4EF /* KeyPairProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB5520924D3A006BF351 /* KeyPairProtocol.swift */; };
+		53008FA4253609D1006FE4EF /* SecretKeyGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD35BB5920925566006BF351 /* SecretKeyGenerator.swift */; };
+		53008FA5253609D1006FE4EF /* ExitCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1E4D0E20922C9E00BE7A3F /* ExitCode.swift */; };
+		53008FA6253609D1006FE4EF /* SecretBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038365141A5A51D20081136D /* SecretBox.swift */; };
+		53008FA7253609D1006FE4EF /* Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0942982F1EDDAA3B001236B1 /* Stream.swift */; };
+		53008FA8253609D1006FE4EF /* GenericHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D80561A4ED0B4000B83F9 /* GenericHash.swift */; };
+		53008FA9253609D1006FE4EF /* PWHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097F20D91AF127480088C2FE /* PWHash.swift */; };
+		53008FAA253609D1006FE4EF /* RandomBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D805A1A4F35CA000B83F9 /* RandomBytes.swift */; };
+		53008FAB253609D1006FE4EF /* ShortHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 091C7CD91A507E95002E5351 /* ShortHash.swift */; };
+		53008FAC253609D1006FE4EF /* Sign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 091C7CDB1A50839D002E5351 /* Sign.swift */; };
+		53008FAD253609D1006FE4EF /* Sodium.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D80541A4ECCD7000B83F9 /* Sodium.swift */; };
+		53008FAE253609D1006FE4EF /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D805C1A4F4F72000B83F9 /* Utils.swift */; };
+		53008FAF253609D1006FE4EF /* KeyExchange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6373E11E7B5E0800F04E72 /* KeyExchange.swift */; };
+		53008FB0253609D1006FE4EF /* Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0918C771E92489100C1DC33 /* Auth.swift */; };
+		53008FB1253609D1006FE4EF /* KeyDerivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A274051F13AD9300958702 /* KeyDerivation.swift */; };
+		53008FB2253609D1006FE4EF /* SecretStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A5AC111F74466700D3200B /* SecretStream.swift */; };
+		53008FB3253609D1006FE4EF /* Aead.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87EEC3F2063C655006C830D /* Aead.swift */; };
+		53008FB4253609E2006FE4EF /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901645021AE376C100163E3E /* Helpers.swift */; };
+		53008FB525360A54006FE4EF /* Sodium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53008F9425360973006FE4EF /* Sodium.framework */; };
+		53008FB625360A54006FE4EF /* Sodium.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 53008F9425360973006FE4EF /* Sodium.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6096E7321F194FA800E6599F /* KeyDerivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A274051F13AD9300958702 /* KeyDerivation.swift */; };
 		60C211E71EB73D3900882AD0 /* Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0918C771E92489100C1DC33 /* Auth.swift */; };
 		60CB27B81EB371480079CA46 /* Sodium.h in Headers */ = {isa = PBXBuildFile; fileRef = 09A943CC1A4EB5F500C8A04F /* Sodium.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -114,6 +146,13 @@
 			remoteGlobalIDString = 09A943C61A4EB5F500C8A04F;
 			remoteInfo = Sodium;
 		};
+		53008FB725360A54006FE4EF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 09A943BE1A4EB5F500C8A04F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 53008F9325360973006FE4EF;
+			remoteInfo = Sodium_tvOS;
+		};
 		60D50A6C1FD1778300FCE80F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 09A943BE1A4EB5F500C8A04F /* Project object */;
@@ -162,6 +201,28 @@
 			dstSubfolderSpec = 10;
 			files = (
 				093EFE3D24DB1D8900D7ED92 /* Sodium.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		53008F9E2536098E006FE4EF /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				53008F9D2536098E006FE4EF /* Clibsodium.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		53008FB925360A54006FE4EF /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				53008FB625360A54006FE4EF /* Sodium.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -276,6 +337,16 @@
 		09BB142E1E75CA6F00659F17 /* crypto_kx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_kx.h; sourceTree = "<group>"; };
 		09BB142F1E75CA6F00659F17 /* crypto_secretbox_xchacha20poly1305.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_secretbox_xchacha20poly1305.h; sourceTree = "<group>"; };
 		09BB14301E75CA6F00659F17 /* crypto_stream_xchacha20.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_stream_xchacha20.h; sourceTree = "<group>"; };
+		53008F6D25360875006FE4EF /* Example tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		53008F7F253608B0006FE4EF /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ViewController.swift; path = Examples/tvOS/ViewController.swift; sourceTree = "<group>"; };
+		53008F81253608B0006FE4EF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Examples/tvOS/Assets.xcassets; sourceTree = "<group>"; };
+		53008F82253608B0006FE4EF /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Examples/tvOS/AppDelegate.swift; sourceTree = "<group>"; };
+		53008F83253608B0006FE4EF /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Examples/tvOS/Info.plist; sourceTree = "<group>"; };
+		53008F8A253608D6006FE4EF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Examples/tvOS/Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		53008F8C253608D6006FE4EF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Examples/tvOS/Base.lproj/tvOSMain.storyboard; sourceTree = "<group>"; };
+		53008F9425360973006FE4EF /* Sodium.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Sodium.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		53008F9625360973006FE4EF /* Sodium.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Sodium.h; sourceTree = "<group>"; };
+		53008F9725360973006FE4EF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		65437DA2203AF0610027D691 /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		65437DA3203AF0610027D691 /* Sodium.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Sodium.podspec; sourceTree = "<group>"; };
 		7D6373E11E7B5E0800F04E72 /* KeyExchange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyExchange.swift; sourceTree = "<group>"; };
@@ -336,6 +407,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		53008F6A25360875006FE4EF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				53008FB525360A54006FE4EF /* Sodium.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		53008F9125360973006FE4EF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				53008F9C2536098E006FE4EF /* Clibsodium.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		901644B31AE36EA700163E3E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -388,6 +475,7 @@
 				901644AF1AE36D6000163E3E /* Examples */,
 				09A943C91A4EB5F500C8A04F /* Sodium */,
 				09A943D61A4EB5F500C8A04F /* SodiumTests */,
+				53008F9525360973006FE4EF /* Sodium */,
 				09A943C81A4EB5F500C8A04F /* Products */,
 				D891FE9C2164307B0092AA84 /* Frameworks */,
 			);
@@ -404,6 +492,8 @@
 				D891FE9421642CB40092AA84 /* Sodium.framework */,
 				D87D515521647597006D2C03 /* Example Watch.app */,
 				D87D516121647598006D2C03 /* Example Watch Extension.appex */,
+				53008F6D25360875006FE4EF /* Example tvOS.app */,
+				53008F9425360973006FE4EF /* Sodium.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -528,6 +618,28 @@
 			path = libsodium;
 			sourceTree = "<group>";
 		};
+		53008F6825360814006FE4EF /* tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				53008F89253608D6006FE4EF /* LaunchScreen.storyboard */,
+				53008F8B253608D6006FE4EF /* tvOSMain.storyboard */,
+				53008F82253608B0006FE4EF /* AppDelegate.swift */,
+				53008F81253608B0006FE4EF /* Assets.xcassets */,
+				53008F83253608B0006FE4EF /* Info.plist */,
+				53008F7F253608B0006FE4EF /* ViewController.swift */,
+			);
+			name = tvOS;
+			sourceTree = "<group>";
+		};
+		53008F9525360973006FE4EF /* Sodium */ = {
+			isa = PBXGroup;
+			children = (
+				53008F9625360973006FE4EF /* Sodium.h */,
+				53008F9725360973006FE4EF /* Info.plist */,
+			);
+			path = Sodium;
+			sourceTree = "<group>";
+		};
 		901644AF1AE36D6000163E3E /* Examples */ = {
 			isa = PBXGroup;
 			children = (
@@ -536,6 +648,7 @@
 				D87D515621647597006D2C03 /* Watch */,
 				D87D516521647598006D2C03 /* Watch Extension */,
 				901644B01AE36D6D00163E3E /* iOS */,
+				53008F6825360814006FE4EF /* tvOS */,
 			);
 			name = Examples;
 			sourceTree = "<group>";
@@ -644,6 +757,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		53008F8F25360973006FE4EF /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				53008F9825360973006FE4EF /* Sodium.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		90C75E911AE3571900F1E749 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -698,6 +819,44 @@
 			productName = SodiumTests;
 			productReference = 09A943D21A4EB5F500C8A04F /* SodiumTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		53008F6C25360875006FE4EF /* Example tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 53008F7C25360876006FE4EF /* Build configuration list for PBXNativeTarget "Example tvOS" */;
+			buildPhases = (
+				53008F6925360875006FE4EF /* Sources */,
+				53008F6A25360875006FE4EF /* Frameworks */,
+				53008F6B25360875006FE4EF /* Resources */,
+				53008FB925360A54006FE4EF /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				53008FB825360A54006FE4EF /* PBXTargetDependency */,
+			);
+			name = "Example tvOS";
+			productName = "Example tvOS";
+			productReference = 53008F6D25360875006FE4EF /* Example tvOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		53008F9325360973006FE4EF /* Sodium_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 53008F9925360973006FE4EF /* Build configuration list for PBXNativeTarget "Sodium_tvOS" */;
+			buildPhases = (
+				53008F8F25360973006FE4EF /* Headers */,
+				53008F9025360973006FE4EF /* Sources */,
+				53008F9125360973006FE4EF /* Frameworks */,
+				53008F9225360973006FE4EF /* Resources */,
+				53008F9E2536098E006FE4EF /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Sodium_tvOS;
+			productName = Sodium;
+			productReference = 53008F9425360973006FE4EF /* Sodium.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 		901644B51AE36EA700163E3E /* Example iOS */ = {
 			isa = PBXNativeTarget;
@@ -817,7 +976,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 0700;
-				LastSwiftUpdateCheck = 1000;
+				LastSwiftUpdateCheck = 1170;
 				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Frank Denis";
 				TargetAttributes = {
@@ -829,6 +988,13 @@
 					09A943D11A4EB5F500C8A04F = {
 						CreatedOnToolsVersion = 6.1.1;
 						LastSwiftMigration = "";
+					};
+					53008F6C25360875006FE4EF = {
+						CreatedOnToolsVersion = 11.7;
+						LastSwiftMigration = 1170;
+					};
+					53008F9325360973006FE4EF = {
+						CreatedOnToolsVersion = 11.7;
 					};
 					901644B51AE36EA700163E3E = {
 						CreatedOnToolsVersion = 6.3;
@@ -875,10 +1041,12 @@
 				09A943D11A4EB5F500C8A04F /* SodiumTests */,
 				90C75E931AE3571900F1E749 /* Sodium_OSX */,
 				D891FE9321642CB40092AA84 /* Sodium_watchOS */,
+				53008F9325360973006FE4EF /* Sodium_tvOS */,
 				901644B51AE36EA700163E3E /* Example iOS */,
 				901644DB1AE36F2D00163E3E /* Example OSX */,
 				D87D515421647597006D2C03 /* Example Watch */,
 				D87D516021647598006D2C03 /* Example Watch Extension */,
+				53008F6C25360875006FE4EF /* Example tvOS */,
 			);
 		};
 /* End PBXProject section */
@@ -892,6 +1060,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		09A943D01A4EB5F500C8A04F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		53008F6B25360875006FE4EF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				53008F8D253608D6006FE4EF /* LaunchScreen.storyboard in Resources */,
+				53008F86253608B0006FE4EF /* Assets.xcassets in Resources */,
+				53008F8E253608D6006FE4EF /* tvOSMain.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		53008F9225360973006FE4EF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -990,6 +1175,44 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		53008F6925360875006FE4EF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				53008FB4253609E2006FE4EF /* Helpers.swift in Sources */,
+				53008F87253608B0006FE4EF /* AppDelegate.swift in Sources */,
+				53008F84253608B0006FE4EF /* ViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		53008F9025360973006FE4EF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				53008F9F253609D1006FE4EF /* Box.swift in Sources */,
+				53008FA0253609D1006FE4EF /* Bytes.swift in Sources */,
+				53008FA1253609D1006FE4EF /* NonceGenerator.swift in Sources */,
+				53008FA2253609D1006FE4EF /* KeyPairGenerator.swift in Sources */,
+				53008FA3253609D1006FE4EF /* KeyPairProtocol.swift in Sources */,
+				53008FA4253609D1006FE4EF /* SecretKeyGenerator.swift in Sources */,
+				53008FA5253609D1006FE4EF /* ExitCode.swift in Sources */,
+				53008FA6253609D1006FE4EF /* SecretBox.swift in Sources */,
+				53008FA7253609D1006FE4EF /* Stream.swift in Sources */,
+				53008FA8253609D1006FE4EF /* GenericHash.swift in Sources */,
+				53008FA9253609D1006FE4EF /* PWHash.swift in Sources */,
+				53008FAA253609D1006FE4EF /* RandomBytes.swift in Sources */,
+				53008FAB253609D1006FE4EF /* ShortHash.swift in Sources */,
+				53008FAC253609D1006FE4EF /* Sign.swift in Sources */,
+				53008FAD253609D1006FE4EF /* Sodium.swift in Sources */,
+				53008FAE253609D1006FE4EF /* Utils.swift in Sources */,
+				53008FAF253609D1006FE4EF /* KeyExchange.swift in Sources */,
+				53008FB0253609D1006FE4EF /* Auth.swift in Sources */,
+				53008FB1253609D1006FE4EF /* KeyDerivation.swift in Sources */,
+				53008FB2253609D1006FE4EF /* SecretStream.swift in Sources */,
+				53008FB3253609D1006FE4EF /* Aead.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		901644B21AE36EA700163E3E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1083,6 +1306,11 @@
 			target = 09A943C61A4EB5F500C8A04F /* Sodium_iOS */;
 			targetProxy = 09A943D41A4EB5F500C8A04F /* PBXContainerItemProxy */;
 		};
+		53008FB825360A54006FE4EF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 53008F9325360973006FE4EF /* Sodium_tvOS */;
+			targetProxy = 53008FB725360A54006FE4EF /* PBXContainerItemProxy */;
+		};
 		60D50A6D1FD1778300FCE80F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 09A943C61A4EB5F500C8A04F /* Sodium_iOS */;
@@ -1106,6 +1334,22 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		53008F89253608D6006FE4EF /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				53008F8A253608D6006FE4EF /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		53008F8B253608D6006FE4EF /* tvOSMain.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				53008F8C253608D6006FE4EF /* Base */,
+			);
+			name = tvOSMain.storyboard;
+			sourceTree = "<group>";
+		};
 		901645371AE37E5800163E3E /* LaunchScreen.xib */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -1361,6 +1605,139 @@
 				PRODUCT_NAME = SodiumTests;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		53008F7D25360876006FE4EF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Examples/tvOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vucontacts.swiftodium.Example-tvOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 13.4;
+			};
+			name = Debug;
+		};
+		53008F7E25360876006FE4EF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Examples/tvOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vucontacts.swiftodium.Example-tvOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 13.4;
+			};
+			name = Release;
+		};
+		53008F9A25360973006FE4EF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Sodium/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.pureftpd.swiftodium.Sodium;
+				PRODUCT_NAME = Sodium;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 13.4;
+			};
+			name = Debug;
+		};
+		53008F9B25360973006FE4EF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Sodium/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.pureftpd.swiftodium.Sodium;
+				PRODUCT_NAME = Sodium;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 13.4;
 			};
 			name = Release;
 		};
@@ -1764,6 +2141,24 @@
 			buildConfigurations = (
 				09A943E11A4EB5F500C8A04F /* Debug */,
 				09A943E21A4EB5F500C8A04F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		53008F7C25360876006FE4EF /* Build configuration list for PBXNativeTarget "Example tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				53008F7D25360876006FE4EF /* Debug */,
+				53008F7E25360876006FE4EF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		53008F9925360973006FE4EF /* Build configuration list for PBXNativeTarget "Sodium_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				53008F9A25360973006FE4EF /* Debug */,
+				53008F9B25360973006FE4EF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Sodium.xcodeproj/xcshareddata/xcschemes/Sodium_iOS.xcscheme
+++ b/Sodium.xcodeproj/xcshareddata/xcschemes/Sodium_iOS.xcscheme
@@ -41,6 +41,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "09A943C61A4EB5F500C8A04F"
+            BuildableName = "Sodium.framework"
+            BlueprintName = "Sodium_iOS"
+            ReferencedContainer = "container:Sodium.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,17 +62,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "09A943C61A4EB5F500C8A04F"
-            BuildableName = "Sodium.framework"
-            BlueprintName = "Sodium_iOS"
-            ReferencedContainer = "container:Sodium.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -84,8 +82,6 @@
             ReferencedContainer = "container:Sodium.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sodium.xcodeproj/xcshareddata/xcschemes/Sodium_tvOS.xcscheme
+++ b/Sodium.xcodeproj/xcshareddata/xcschemes/Sodium_tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1170"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "90C75E931AE3571900F1E749"
+               BlueprintIdentifier = "53008F9325360973006FE4EF"
                BuildableName = "Sodium.framework"
-               BlueprintName = "Sodium_OSX"
+               BlueprintName = "Sodium_tvOS"
                ReferencedContainer = "container:Sodium.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -43,9 +43,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "90C75E931AE3571900F1E749"
+            BlueprintIdentifier = "53008F9325360973006FE4EF"
             BuildableName = "Sodium.framework"
-            BlueprintName = "Sodium_OSX"
+            BlueprintName = "Sodium_tvOS"
             ReferencedContainer = "container:Sodium.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -59,9 +59,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "90C75E931AE3571900F1E749"
+            BlueprintIdentifier = "53008F9325360973006FE4EF"
             BuildableName = "Sodium.framework"
-            BlueprintName = "Sodium_OSX"
+            BlueprintName = "Sodium_tvOS"
             ReferencedContainer = "container:Sodium.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Sodium.xcodeproj/xcshareddata/xcschemes/Sodium_watchOS.xcscheme
+++ b/Sodium.xcodeproj/xcshareddata/xcschemes/Sodium_watchOS.xcscheme
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:Sodium.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
This PR adds tvOS support, specifically the following are added:

- Adds `Sodium_tvOS` framework build target and scheme.
- Adds `Example tvOS` app build target and scheme
  - This uses the same code as the `Example iOS` app in `ViewController.swift` to test that basic functionality is working as expected when running on tvOS.