### PR TITLE
Resolve Xcode 12 Package manifest resolution error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This PR is effectively a revert of the PR https://github.com/jedisct1/swift-sodium/pull/215 (which was made in error it turns out):

- Sets `// swift-tools-version:5.3` in `Package.swift` since `.binaryTarget(…)` is only available in Xcode 12.0 and above.