### PR TITLE
Use xcframework only for supported OS

### DIFF
--- a/Clibsodium/module.modulemap
+++ b/Clibsodium/module.modulemap
@@ -1,0 +1,5 @@
+module Clibsodium [system] {
+  header "shim.h"
+  link "sodium"
+  export *
+}

--- a/Clibsodium/shim.h
+++ b/Clibsodium/shim.h
@@ -1,0 +1,1 @@
+#include <sodium.h>

--- a/Package.swift
+++ b/Package.swift
@@ -1,31 +1,42 @@
 // swift-tools-version:5.3
 import PackageDescription
 
-var products: [Product] = [.library(name: "Sodium", targets: ["Sodium"])]
-var dependencies: [Package.Dependency] = []
-var targets: [Target] = [
-    .target(
-        name: "Sodium",
-        dependencies: ["Clibsodium"],
-        path: "Sodium",
-        exclude: ["libsodium", "Info.plist"]),
-    .testTarget(
-        name: "SodiumTests",
-        dependencies: ["Sodium"],
-        exclude: ["Info.plist"]),
-]
-
-
+let clibsodiumTarget: Target
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-products.append(.library(name: "Clibsodium", targets: ["Clibsodium"]))
-targets.append(.binaryTarget(name: "Clibsodium", path: "Clibsodium.xcframework"))
+    clibsodiumTarget = .binaryTarget(
+        name: "Clibsodium",
+        path: "Clibsodium.xcframework")
 #else
-dependencies.append(.package(name: "Clibsodium", url: "https://github.com/TICESoftware/Clibsodium.git", from: "1.0.0"))
+    clibsodiumTarget = .systemLibrary(
+        name: "Clibsodium",
+        path: "Clibsodium",
+        pkgConfig: "libsodium",
+        providers: [
+            .apt(["libsodium-dev"]),
+            .brew(["libsodium"])
+        ])
 #endif
 
 let package = Package(
     name: "Sodium",
-    products: products,
-    dependencies: dependencies,
-    targets: targets
+    products: [
+        .library(
+            name: "Clibsodium",
+            targets: ["Clibsodium"]),
+        .library(
+            name: "Sodium",
+            targets: ["Sodium"]),
+    ],
+    targets: [
+        clibsodiumTarget,
+        .target(
+            name: "Sodium",
+            dependencies: ["Clibsodium"],
+            path: "Sodium",
+            exclude: ["libsodium", "Info.plist"]),
+        .testTarget(
+            name: "SodiumTests",
+            dependencies: ["Sodium"],
+            exclude: ["Info.plist"]),
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,28 +1,31 @@
 // swift-tools-version:5.3
 import PackageDescription
 
+var products: [Product] = [.library(name: "Sodium", targets: ["Sodium"])]
+var dependencies: [Package.Dependency] = []
+var targets: [Target] = [
+    .target(
+        name: "Sodium",
+        dependencies: ["Clibsodium"],
+        path: "Sodium",
+        exclude: ["libsodium", "Info.plist"]),
+    .testTarget(
+        name: "SodiumTests",
+        dependencies: ["Sodium"],
+        exclude: ["Info.plist"]),
+]
+
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+products.append(.library(name: "Clibsodium", targets: ["Clibsodium"]))
+targets.append(.binaryTarget(name: "Clibsodium", path: "Clibsodium.xcframework"))
+#else
+dependencies.append(.package(name: "Clibsodium", url: "https://github.com/TICESoftware/Clibsodium.git", from: "1.0.0"))
+#endif
+
 let package = Package(
     name: "Sodium",
-    products: [
-        .library(
-            name: "Clibsodium",
-            targets: ["Clibsodium"]),
-        .library(
-            name: "Sodium",
-            targets: ["Sodium"]),
-    ],
-    targets: [
-        .binaryTarget(
-            name: "Clibsodium",
-            path: "Clibsodium.xcframework"),
-        .target(
-            name: "Sodium",
-            dependencies: ["Clibsodium"],
-            path: "Sodium",
-            exclude: ["libsodium", "Info.plist"]),
-        .testTarget(
-            name: "SodiumTests",
-            dependencies: ["Sodium"],
-            exclude: ["Info.plist"]),
-    ]
+    products: products,
+    dependencies: dependencies,
+    targets: targets
 )


### PR DESCRIPTION
This is not quite a solution for the problem of #224, but it's a running workaround. Otherwise, swift-sodium can't be used on server side projects on Linux - this makes it possible again.