### PR TITLE
Circumvent swift bug SR-14038

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let clibsodiumTarget: Target
         providers: [
             .apt(["libsodium-dev"]),
             .brew(["libsodium"]),
-            .yum(["libsodium-devel"])
+            // Waiting for bug to be fixed: https://bugs.swift.org/browse/SR-14038
+            // .yum(["libsodium-devel"])
         ])
 #endif
 


### PR DESCRIPTION
Unfortunately, a swift bug makes it impossible to use swift-sodium on linux. The fix is really quick and easy.

The bug is the following: https://bugs.swift.org/browse/SR-14038