### PR TITLE
Make initializer throwable, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,10 @@
 *.xcworkspace
 DerivedData
 Pods/
-build/
-xcuserdata
+/.build
+xcuserdata/
 .build
 Package.resolved
 .DS_Store
+/Packages
+/*.xcodeproj

--- a/Examples/OSX/AppDelegate.swift
+++ b/Examples/OSX/AppDelegate.swift
@@ -6,7 +6,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var window: NSWindow!
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let aliceKeyPair = sodium.box.keyPair()!
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".bytes

--- a/Examples/Watch Extension/InterfaceController.swift
+++ b/Examples/Watch Extension/InterfaceController.swift
@@ -16,7 +16,7 @@ class InterfaceController: WKInterfaceController {
     override func awake(withContext context: Any?) {
         super.awake(withContext: context)
         
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let aliceKeyPair = sodium.box.keyPair()!
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".bytes

--- a/Examples/iOS/ViewController.swift
+++ b/Examples/iOS/ViewController.swift
@@ -5,7 +5,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let aliceKeyPair = sodium.box.keyPair()!
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".bytes

--- a/Examples/tvOS/ViewController.swift
+++ b/Examples/tvOS/ViewController.swift
@@ -5,7 +5,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let aliceKeyPair = sodium.box.keyPair()!
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".bytes

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -30,7 +30,7 @@ public struct Sodium {
 }
 
 extension Sodium {
-    private static let initCode: Int32 = {
+    private static let initCode: CInt = {
         return sodium_init()
     }()
 }

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -1,7 +1,11 @@
-import Foundation
 import Clibsodium
+import Foundation
 
 public struct Sodium {
+    public enum InitError: Error {
+        case code(Int32)
+    }
+
     public let box = Box()
     public let secretBox = SecretBox()
     public let genericHash = GenericHash()
@@ -17,15 +21,16 @@ public struct Sodium {
     public let secretStream = SecretStream()
     public let aead = Aead()
 
-    public init() {
-        _ = Sodium.once
+    public init() throws {
+        let code = Sodium.initCode
+        guard code >= 0 else {
+            throw InitError.code(code)
+        }
     }
 }
 
 extension Sodium {
-    private static let once: Void = {
-        guard sodium_init() >= 0 else {
-            fatalError("Failed to initialize libsodium")
-        }
+    private static let initCode: Int32 = {
+        return sodium_init()
     }()
 }

--- a/Tests/SodiumTests/ReadmeTests.swift
+++ b/Tests/SodiumTests/ReadmeTests.swift
@@ -28,7 +28,7 @@ class ReadmeTests : XCTestCase {
     ]
 
     func testAuthenticatedEncryption() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let aliceKeyPair = sodium.box.keyPair()!
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".bytes
@@ -47,7 +47,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testAnonymousEncryptionSealedBoxes() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let bobKeyPair = sodium.box.keyPair()!
         let message = "My Test Message".bytes
 
@@ -63,7 +63,7 @@ class ReadmeTests : XCTestCase {
     }
 
 	func testKeyExchange() {
-		let sodium = Sodium()
+		let sodium = try! Sodium()
 		let aliceKeyPair = sodium.keyExchange.keyPair()!
 		let bobKeyPair = sodium.keyExchange.keyPair()!
 
@@ -80,7 +80,7 @@ class ReadmeTests : XCTestCase {
 	}
 
     func testDetachedSignatures() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let message = "My Test Message".bytes
         let keyPair = sodium.sign.keyPair()!
         let signature = sodium.sign.signature(message: message, secretKey: keyPair.secretKey)!
@@ -92,7 +92,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testAttachedSignatures() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let message = "My Test Message".bytes
         let keyPair = sodium.sign.keyPair()!
         let signedMessage = sodium.sign.sign(message: message, secretKey: keyPair.secretKey)!
@@ -102,7 +102,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testSecretKeyAuthenticatedEncryption() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let message = "My Test Message".bytes
         let secretKey = sodium.secretBox.key()
         let encrypted: Bytes = sodium.secretBox.seal(message: message, secretKey: secretKey)!
@@ -112,7 +112,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testDeterministicHashing() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let message = "My Test Message".bytes
         let h = sodium.genericHash.hash(message: message)
 
@@ -120,7 +120,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testKeyedHashing() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let message = "My Test Message".bytes
         let key = "Secret key".bytes
         let h = sodium.genericHash.hash(message: message, key: key)
@@ -129,7 +129,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testStreaming() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let message1 = "My Test ".bytes
         let message2 = "Message".bytes
         let key = "Secret key".bytes
@@ -142,7 +142,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testShortOutputHashing() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let message = "My Test Message".bytes
         let key = sodium.randomBytes.buf(length: sodium.shortHash.KeyBytes)!
         let h = sodium.shortHash.hash(message: message, key: key)
@@ -151,14 +151,14 @@ class ReadmeTests : XCTestCase {
     }
 
     func testRandomNumberGeneration() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let randomData = sodium.randomBytes.buf(length: 1000)
 
         XCTAssertNotNil(randomData)
     }
 
     func testPasswordHashing() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let password = "Correct Horse Battery Staple".bytes
         let hashedStr = sodium.pwHash.str(passwd: password,
                                           opsLimit: sodium.pwHash.OpsLimitInteractive,
@@ -179,13 +179,13 @@ class ReadmeTests : XCTestCase {
     }
 
     func testZeroingMemory() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         var dataToZero = "Message".bytes
         sodium.utils.zero(&dataToZero)
     }
 
     func testConstantTimeComparison() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let secret1 = "Secret key".bytes
         let secret2 = "Secret key".bytes
         let equality = sodium.utils.equals(secret1, secret2)
@@ -194,7 +194,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testConstantTimeHexdecimalEncoding() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let data = "Secret key".bytes
         let hex = sodium.utils.bin2hex(data)
 
@@ -202,7 +202,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testHexDecimalDecoding() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let data1 = sodium.utils.hex2bin("deadbeef")
         let data2 = sodium.utils.hex2bin("de:ad be:ef", ignore: " :")
 
@@ -211,7 +211,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testStream() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let input = "test".bytes
         let key = sodium.stream.key()
         let (output, nonce) = sodium.stream.xor(input: input, secretKey: key)!
@@ -221,7 +221,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testAuth() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let input = "test".bytes
         let key = sodium.auth.key()
         let tag = sodium.auth.tag(message: input, secretKey: key)!
@@ -231,7 +231,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testKeyDerivation() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let secretKey = sodium.keyDerivation.key()
 
         let subKey1 = sodium.keyDerivation.derive(secretKey: secretKey,
@@ -244,7 +244,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testSecretStream() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let message1 = "Message 1".bytes
         let message2 = "Message 2".bytes
         let message3 = "Message 3".bytes
@@ -275,7 +275,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testBase64() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         let b64 = sodium.utils.bin2base64("data".bytes)!
         let b64_2 = sodium.utils.bin2base64("data".bytes, variant: .URLSAFE_NO_PADDING)!
 
@@ -289,7 +289,7 @@ class ReadmeTests : XCTestCase {
     }
 
     func testPadding() {
-        let sodium = Sodium()
+        let sodium = try! Sodium()
         var data = "test".bytes
 
         // make data.count a multiple of 16

--- a/Tests/SodiumTests/SodiumTests.swift
+++ b/Tests/SodiumTests/SodiumTests.swift
@@ -38,7 +38,7 @@ class SodiumTests: XCTestCase {
         ("testUtils", testUtils),
     ]
 
-    let sodium = Sodium()
+    let sodium = try! Sodium()
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
IMO it's better to expect initializer to throw rather than throw silently.
Updated gitignore to match auto-generated one by Xcode (unsure, if `build` should be `/.build` or these are distinct here)